### PR TITLE
Fix test scripts and document environment prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ powerit/
 
 ## Setup
 
+### Initial environment preparation (online)
+
+Run the following commands while your machine still has internet access to download all dependencies:
+
+```bash
+cd backend
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+deactivate
+cd ../frontend && npm install
+cd ../testing && npm install && npx playwright install
+cd ..
+```
+
 ### Backend
 
 1. Navigate to the backend directory:
@@ -39,9 +54,12 @@ powerit/
    cd backend
    ```
 
-2. Install dependencies in the virtual environment:
-   ```
-   ./venv/bin/pip install -r requirements.txt
+2. **Create the virtual environment and install dependencies** (run while the machine has internet access):
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   deactivate
    ```
 
 3. Create a `.env` file with your API key:

--- a/backend/record_all_tests.sh
+++ b/backend/record_all_tests.sh
@@ -14,6 +14,10 @@ then
     exit 0
 fi
 
+# Determine script directory and use its virtual environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 # Activate the virtual environment
 source venv/bin/activate
 
@@ -75,4 +79,4 @@ deactivate
 echo ""
 echo "✅ All tests completed in recording mode."
 echo "New fixtures have been created in the tests/fixtures directory."
-echo "Future test runs will use these fixtures by default unless recording mode is enabled." 
+echo "Future test runs will use these fixtures by default unless recording mode is enabled."

--- a/backend/record_tests.sh
+++ b/backend/record_tests.sh
@@ -8,6 +8,10 @@ if [ -z "$GEMINI_API_KEY" ] || [ -z "$OPENAI_API_KEY" ]; then
     echo "Make sure they are set in your .env file or directly in the environment."
 fi
 
+# Determine script directory and use its virtual environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 # Activate the virtual environment
 source venv/bin/activate
 

--- a/backend/run_tests.sh
+++ b/backend/run_tests.sh
@@ -2,8 +2,18 @@
 
 # Script to run tests using the virtual environment
 
-# Activate the virtual environment
-source venv/bin/activate
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Ensure virtual environment exists
+if [ ! -d "venv" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+else
+    source venv/bin/activate
+fi
 
 # Run tests with specified arguments or all tests if none provided
 if [ $# -eq 0 ]; then
@@ -15,4 +25,4 @@ else
 fi
 
 # Deactivate the virtual environment when done
-deactivate 
+deactivate


### PR DESCRIPTION
## Summary
- ensure run_tests.sh and recording scripts work from any directory
- document environment preparation steps in the README

## Testing
- `./backend/run_tests.sh >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log` *(fails: GEMINI_API_KEY environment variable is required)*