### PR TITLE
Enable offline mode using VCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ You can run both the backend and frontend together using:
 
 Or run them separately:
 
+### Offline Mode
+
+To run the backend without internet access, set `POWERIT_OFFLINE=1`. All calls to
+Gemini, OpenAI and logo fetching will be served from the recorded VCR fixtures.
+
+```bash
+export POWERIT_OFFLINE=1
+./run.sh
+```
+
 ### Backend
 
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,7 @@ The following environment variables are required:
 
 - `GEMINI_API_KEY` - Google Gemini API key
 - `OPENAI_API_KEY` - OpenAI API key (for image generation)
+- `POWERIT_OFFLINE` - Set to `1` to run without internet using recorded fixtures
 
 ### Running the API
 
@@ -64,6 +65,8 @@ python run_api.py
 ```
 
 The server will be available at http://localhost:8000.
+
+To run completely offline, set `POWERIT_OFFLINE=1` before starting the server.
 
 ## Testing
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -3,4 +3,7 @@ Presentation Assistant Backend
 A FastMCP server for creating presentations using Gemini models
 """
 
-__version__ = "0.1.0" 
+__version__ = "0.1.0"
+
+# Enable offline mode if requested
+from . import offline  # noqa: F401

--- a/backend/offline.py
+++ b/backend/offline.py
@@ -1,0 +1,75 @@
+import os
+import importlib.util
+from unittest.mock import patch, MagicMock
+
+OFFLINE = os.environ.get("POWERIT_OFFLINE", "0").lower() in {"1", "true", "yes"}
+
+if OFFLINE:
+    print("Offline mode enabled - using recorded fixtures")
+
+    base_dir = os.path.dirname(__file__)
+    gemini_path = os.path.join(base_dir, "tests", "test_gemini_vcr.py")
+    openai_path = os.path.join(base_dir, "tests", "test_openai_vcr.py")
+
+    spec_g = importlib.util.spec_from_file_location("gemini_vcr", gemini_path)
+    gemini_vcr_module = importlib.util.module_from_spec(spec_g)
+    spec_g.loader.exec_module(gemini_vcr_module)
+    GeminiVCR = gemini_vcr_module.GeminiVCR
+
+    spec_o = importlib.util.spec_from_file_location("openai_vcr", openai_path)
+    openai_vcr_module = importlib.util.module_from_spec(spec_o)
+    spec_o.loader.exec_module(openai_vcr_module)
+    OpenAIVCR = openai_vcr_module.OpenAIVCR
+
+    gemini_vcr = GeminiVCR()
+    openai_vcr = OpenAIVCR()
+
+    import google.generativeai as genai
+    patch.object(
+        genai.GenerativeModel,
+        "generate_content_async",
+        side_effect=gemini_vcr.mock_generate_content_async(
+            genai.GenerativeModel.generate_content_async
+        ),
+    ).start()
+    patch.object(
+        genai.GenerativeModel,
+        "generate_content",
+        side_effect=gemini_vcr.mock_generate_content(
+            genai.GenerativeModel.generate_content
+        ),
+    ).start()
+
+    def _offline_openai(*args, **kwargs):
+        client = MagicMock()
+        images = MagicMock()
+        images.generate = lambda **kw: openai_vcr.mock_openai_images_generate(**kw)
+        client.images = images
+        return client
+
+    patch("openai.OpenAI", new=_offline_openai).start()
+
+    from tools import logo_fetcher
+
+    def _offline_search_logo(term):
+        fixture = gemini_vcr.generate_fixture_name([term], {})
+        data = gemini_vcr.load_recording(fixture)
+        if data:
+            return data
+        return {"name": term, "url": "", "image_url": ""}
+
+    def _offline_download_logo(term, filename=None):
+        path = os.path.join(logo_fetcher.downloaded_logos_dir, f"{term.lower().replace(' ', '_')}.svg")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        if not os.path.exists(path):
+            with open(path, "w") as f:
+                f.write(
+                    f"<svg xmlns='http://www.w3.org/2000/svg' width='200' height='100'><text x='10' y='50'>{term}</text></svg>"
+                )
+        return True, path
+
+    patch("tools.logo_fetcher.search_logo", new=_offline_search_logo).start()
+    patch("tools.logo_fetcher.download_logo", new=_offline_download_logo).start()
+    patch.object(logo_fetcher.LogoFetcher, "search_logo", _offline_search_logo).start()
+    patch.object(logo_fetcher.LogoFetcher, "download_logo", _offline_download_logo).start()
+


### PR DESCRIPTION
## Summary
- add offline patching module that reuses VCR fixtures
- load offline patches automatically when backend package is imported
- support `POWERIT_OFFLINE` env var in config
- document offline mode in READMEs

## Testing
- `bash backend/run_tests.sh`