### PR TITLE
Add workflow e2e tests and testid hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NC := \033[0m # No Color
 INFO := @echo "$(GREEN)$(1)$(NC)"
 WARN := @echo "$(YELLOW)$(1)$(NC)"
 
-.PHONY: e2e e2e-headed e2e-debug e2e-list help
+.PHONY: e2e e2e-headed e2e-debug e2e-list e2e-install help
 
 # Default target when just running `make`
 help:
@@ -23,6 +23,7 @@ help:
 	@echo "  $(YELLOW)make e2e-debug$(NC)      - Run E2E tests with debugging enabled (headed + slow motion)"
 	@echo "  $(YELLOW)make e2e-test$(NC) test=file-name - Run specific E2E tests (e.g., make e2e-test test=presentations-list)"
 	@echo "  $(YELLOW)make e2e-list$(NC)       - List all available E2E tests"
+	@echo "  $(YELLOW)make e2e-install$(NC)    - Install Playwright browsers"
 	@echo ""
 	@echo "$(GREEN)Examples:$(NC)"
 	@echo "  $(YELLOW)make e2e-test test=presentations-list$(NC)"
@@ -59,4 +60,10 @@ e2e-test:
 # List all available E2E tests
 e2e-list:
 	$(call INFO,Available E2E tests:)
-	@find $(E2E_DIR) -name "*.spec.ts" | sed 's|$(E2E_DIR)/||g' | sed 's|\.spec\.ts$$||g' | sort 
+	@find $(E2E_DIR) -name "*.spec.ts" | sed 's|$(E2E_DIR)/||g' | sed 's|\.spec\.ts$$||g' | sort
+	
+# Install Playwright browsers
+e2e-install:
+	$(call INFO,Installing Playwright browsers...)
+	cd $(TESTING_DIR) && npx playwright install
+	$(call INFO,Browsers installed.)

--- a/frontend/app/edit/[id]/page.tsx
+++ b/frontend/app/edit/[id]/page.tsx
@@ -448,6 +448,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
                   onClick={savePresentation}
                   className="flex items-center gap-1 hover:bg-primary-50 hover:text-primary-600 transition-colors"
                   disabled={isSaving}
+                  data-testid="save-button"
                 >
                   {isSaving ? (
                     <span className="flex items-center gap-1">
@@ -464,6 +465,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
                 <Button
                   onClick={handleExport}
                   className="bg-primary hover:bg-primary-600 text-white flex items-center gap-1 transition-all duration-300 shadow-md hover:shadow-primary-500/25"
+                  data-testid="export-pptx-button"
                 >
                   <Download size={18} />
                   Export PPTX

--- a/frontend/components/steps/illustration-step.tsx
+++ b/frontend/components/steps/illustration-step.tsx
@@ -207,6 +207,7 @@ export default function IllustrationStep({
               onClick={generateAllImages}
               className="bg-primary hover:bg-primary-600 text-white"
               disabled={isGenerating}
+              data-testid="run-images-button"
             >
               {isGenerating ? (
                 <span className="flex items-center gap-2">
@@ -239,6 +240,7 @@ export default function IllustrationStep({
               onClick={generateAllImages}
               className="bg-primary hover:bg-primary-600 text-white px-6"
               size="lg"
+              data-testid="run-images-button"
             >
               <Wand2 size={16} className="mr-2" />
               Generate Images
@@ -332,6 +334,7 @@ export default function IllustrationStep({
                             }}
                             disabled={isGenerating}
                             className="flex-shrink-0"
+                            data-testid="generate-image-button"
                           >
                             <RefreshCw size={16} className={isGenerating ? "animate-spin" : ""} />
                           </Button>

--- a/frontend/components/steps/research-step.tsx
+++ b/frontend/components/steps/research-step.tsx
@@ -258,6 +258,7 @@ export default function ResearchStep({ presentation, setPresentation, savePresen
                     placeholder="Enter a topic for your presentation (e.g., 'The Future of Artificial Intelligence')"
                     rows={3}
                     className="resize-none border-gray-200 focus:border-primary-300 focus:ring focus:ring-primary-200 transition-all"
+                    data-testid="research-topic-input"
                   />
                 </div>
 
@@ -265,6 +266,7 @@ export default function ResearchStep({ presentation, setPresentation, savePresen
                   onClick={handleGenerateContent}
                   className="w-full bg-primary hover:bg-primary-600 text-white transition-all duration-300"
                   disabled={isGenerating || !topic.trim()}
+                  data-testid="run-research-button"
                 >
                   {isGenerating ? (
                     <span className="flex items-center gap-2">
@@ -311,6 +313,7 @@ export default function ResearchStep({ presentation, setPresentation, savePresen
                     placeholder="Enter your research notes, key points, and any other information you want to include in your presentation..."
                     rows={12}
                     className="resize-none border-gray-200 focus:border-primary-300 focus:ring focus:ring-primary-200 transition-all"
+                    data-testid="manual-research-textarea"
                   />
                 </div>
               </CardContent>

--- a/frontend/components/steps/slides-step.tsx
+++ b/frontend/components/steps/slides-step.tsx
@@ -130,6 +130,7 @@ export default function SlidesStep({
               onClick={handleGenerateSlides}
               className="bg-primary hover:bg-primary-600 text-white px-6 py-2"
               disabled={isGenerating}
+              data-testid="run-slides-button"
             >
               {isGenerating ? (
                 <span className="flex items-center gap-2">
@@ -196,6 +197,7 @@ export default function SlidesStep({
                       variant="outline"
                       className="w-full flex items-center justify-center gap-1 border-dashed border-gray-300 hover:border-primary-300 hover:bg-primary-50 transition-colors"
                       onClick={addNewSlide}
+                      data-testid="add-slide-button"
                     >
                       <Plus size={16} />
                       Add Slide
@@ -314,6 +316,7 @@ export default function SlidesStep({
                     <Button
                       onClick={addNewSlide}
                       className="bg-primary hover:bg-primary-600 text-white transition-all duration-300 shadow-md hover:shadow-primary-500/25"
+                      data-testid="add-first-slide-button"
                     >
                       Add Your First Slide
                     </Button>

--- a/frontend/components/workflow-steps.tsx
+++ b/frontend/components/workflow-steps.tsx
@@ -104,6 +104,7 @@ export default function WorkflowSteps({
                       className="w-8 h-8 p-0 rounded-full bg-primary-500 hover:bg-primary-600 text-white shadow-lg"
                       size="icon"
                       title="Continue to next step"
+                      data-testid="continue-button"
                     >
                       {isProcessing ? (
                         <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
@@ -120,6 +121,7 @@ export default function WorkflowSteps({
             <button
               onClick={() => handleStepClick(index)}
               disabled={!isStepEnabled(index)}
+              data-testid={`step-nav-${step.toLowerCase()}`}
               className={`w-8 h-8 rounded-full flex items-center justify-center z-10 transition-all duration-300 ${
                 isStepCompleted(index)
                   ? "bg-primary-500 text-white"

--- a/testing/e2e/presentation-steps.spec.ts
+++ b/testing/e2e/presentation-steps.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { waitForNetworkIdle, createPresentation, runStepAndWaitForCompletion, verifyStepDependencies, getStepStatus } from './utils';
+
+/**
+ * End-to-end test covering the full presentation workflow
+ */
+
+test.describe('Presentation Workflow', () => {
+  test('should run steps sequentially', async ({ page }) => {
+    const name = `E2E Workflow ${Date.now()}`;
+
+    // Navigate to home and ensure page is ready
+    await page.goto('http://localhost:3000');
+    await waitForNetworkIdle(page);
+
+    // Create a new presentation via the helper
+    await createPresentation(page, name, 'Automation testing');
+
+    // Should end up on the edit page
+    await expect(page).toHaveURL(/\/edit\/\d+/);
+
+    // Run slides generation step
+    await runStepAndWaitForCompletion(page, 'slides', 60000);
+    expect(await verifyStepDependencies(page)).toBe(true);
+    expect(await getStepStatus(page, 'slides')).toMatch(/completed|processing/);
+
+    // Continue with images step
+    await page.getByTestId('continue-button').click();
+    await runStepAndWaitForCompletion(page, 'images', 60000);
+    expect(await verifyStepDependencies(page)).toBe(true);
+    expect(await getStepStatus(page, 'images')).toMatch(/completed|processing/);
+
+    // Continue to compiled step
+    await page.getByTestId('continue-button').click();
+    await page.waitForTimeout(1000);
+    expect(await getStepStatus(page, 'compiled')).toMatch(/pending|processing|completed/);
+
+    // Continue to PPTX step
+    await page.getByTestId('continue-button').click();
+    await page.waitForTimeout(1000);
+    await expect(page.getByTestId('export-pptx-button')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- allow Playwright tests to use `data-testid` selectors in workflow steps
- expose run buttons with `data-testid` attributes
- add Playwright e2e test covering full presentation workflow
- improve Makefile with `e2e-install` helper

## Testing
- `make e2e-list`
- `make e2e` *(fails: EHOSTUNREACH)*