### PR TITLE
Integrate wizard with modify API and offline support

### DIFF
--- a/backend/test_offline_modify.py
+++ b/backend/test_offline_modify.py
@@ -1,0 +1,15 @@
+import os
+import asyncio
+from tools.modify import modify_single_slide
+from tools.slides import OFFLINE_SLIDES_RESPONSE
+
+os.environ["POWERIT_OFFLINE"] = "1"
+
+async def test_offline_modify_single_slide():
+    compiled = OFFLINE_SLIDES_RESPONSE
+    research = {"content": "dummy"}
+    result = await modify_single_slide(compiled, research, "Improve", 0)
+    assert result["modified_slide"]["fields"]["title"].startswith("Modified")
+
+if __name__ == "__main__":
+    asyncio.run(test_offline_modify_single_slide())

--- a/frontend/app/edit/[id]/page.tsx
+++ b/frontend/app/edit/[id]/page.tsx
@@ -246,7 +246,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
     setWizardContext(context)
   }
 
-  const applyWizardChanges = (changes: any) => {
+  const applyWizardChanges = async (changes: any) => {
     if (!presentation) return
 
     if (wizardContext === "single" && currentSlide) {
@@ -269,7 +269,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
       }
     }
 
-    savePresentation()
+    await savePresentation()
 
     toast({
       title: "Changes applied",

--- a/frontend/components/wizard/wizard.tsx
+++ b/frontend/components/wizard/wizard.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import type { Presentation, Slide } from "@/lib/types"
 import WizardMessage from "@/components/wizard/wizard-message"
 import WizardSuggestion from "@/components/wizard/wizard-suggestion"
+import { api } from "@/lib/api"
 
 interface WizardProps {
   presentation: Presentation
@@ -36,66 +37,35 @@ export default function Wizard({ presentation, currentSlide, context, step, onAp
   const sendMessage = async () => {
     if (!input.trim()) return
 
-    // Add user message
     const userMessage = { role: "user" as const, content: input }
     setMessages((prev) => [...prev, userMessage])
     setInput("")
     setIsLoading(true)
 
     try {
-      // In a real app, this would be an API call to a backend
-      await new Promise((resolve) => setTimeout(resolve, 1500))
-
-      // Generate a response based on the context and step
       let response = ""
-      let suggestedChanges = null
+      let suggestedChanges = null as any
 
-      if (context === "single" && currentSlide) {
-        // Single slide context
-        if (step === "Slides") {
-          response = generateSlideResponse(currentSlide, input)
+      if (context === "single" && currentSlide && step === "Slides") {
+        const slideIndex = presentation.slides.findIndex(s => s.id === currentSlide.id)
+        const apiResp = await api.modifyPresentation(presentation.id, input, slideIndex, "slides")
+        const mod = apiResp.modified_slide
+        response = "Here are some improvements for the slide.";
+        if (mod && mod.fields) {
           suggestedChanges = {
             slide: {
-              title: currentSlide.title.includes("Introduction")
-                ? currentSlide.title
-                : `Enhanced: ${currentSlide.title}`,
-              content: enhanceSlideContent(currentSlide.content),
-            },
+              ...currentSlide,
+              title: mod.fields.title || currentSlide.title,
+              content: Array.isArray(mod.fields.content) ? mod.fields.content.join("\n") : (mod.fields.content || currentSlide.content)
+            }
           }
-        } else if (step === "Illustration") {
-          response = generateIllustrationResponse(currentSlide, input)
-          suggestedChanges = {
-            slide: {
-              imagePrompt: generateBetterImagePrompt(currentSlide),
-            },
-          }
-        } else {
-          response = `I can help you improve this slide. Based on the content, I suggest making the title more engaging and adding more details to the content.`
         }
       } else {
-        // All slides context
-        if (step === "Research") {
-          response = `Based on your research topic "${
-            presentation.topic || "your presentation"
-          }", I recommend structuring your presentation with an engaging introduction, 3-4 key points, and a strong conclusion. Would you like me to suggest a complete outline?`
-        } else if (step === "Slides") {
-          response = `I've analyzed your slides and have some suggestions to improve the flow and content. Would you like me to enhance the titles and content for better engagement?`
-          suggestedChanges = {
-            slides: presentation.slides.map((slide) => ({
-              ...slide,
-              title: slide.title.includes("Enhanced") ? slide.title : `Enhanced: ${slide.title}`,
-              content: enhanceSlideContent(slide.content),
-            })),
-          }
-        } else {
-          response = `I'm here to help with your ${step.toLowerCase()} step. What specific assistance do you need with your presentation?`
-        }
+        response = "Wizard support for this step is coming soon.";
       }
 
-      // Add assistant response
       setMessages((prev) => [...prev, { role: "assistant", content: response }])
 
-      // Set suggestion if available
       if (suggestedChanges) {
         setSuggestion(suggestedChanges)
       }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -255,6 +255,38 @@ export const api = {
     }
   },
 
+  // Request AI modifications for a slide or presentation
+  async modifyPresentation(id: string | number, prompt: string, slideIndex?: number, currentStep?: string): Promise<any> {
+    const payload: any = { prompt }
+    if (typeof slideIndex === 'number') payload.slide_index = slideIndex
+    if (currentStep) payload.current_step = currentStep
+
+    const response = await fetch(`${API_URL}/presentations/${id}/modify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      mode: 'cors'
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to modify presentation: ${response.status}`)
+    }
+
+    return await response.json()
+  },
+
+  // Save modified presentation data back to the server
+  async saveModifiedPresentation(id: string | number, data: any): Promise<boolean> {
+    const response = await fetch(`${API_URL}/presentations/${id}/save_modified`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+      mode: 'cors'
+    })
+
+    return response.ok
+  },
+
   // Run a specific step for a presentation
   async runPresentationStep(id: string, step: string): Promise<any> {
     try {

--- a/testing/e2e/wizard.spec.ts
+++ b/testing/e2e/wizard.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { createPresentation, runStepAndWaitForCompletion } from './utils';
+
+test.setTimeout(120000);
+
+test.describe('Wizard Slide Modification', () => {
+  test('should request slide modification and apply it', async ({ page }) => {
+    const name = `Wizard Test ${Date.now()}`;
+    const topic = 'Offline wizard topic';
+
+    const id = await createPresentation(page, name, topic);
+
+    await runStepAndWaitForCompletion(page, 'slides');
+
+    // Select first slide thumbnail
+    const firstCard = page.locator('.slide-card').first();
+    await firstCard.click();
+
+    // Find wizard textarea and send a prompt
+    const textarea = page.getByPlaceholder('Ask the AI wizard for help...');
+    await textarea.fill('Improve this slide');
+    await textarea.press('Enter');
+
+    // Wait for suggestion box
+    await page.getByText('Suggested Changes').waitFor({ timeout: 10000 });
+
+    // Apply changes
+    await page.getByRole('button', { name: 'Apply Changes' }).click();
+
+    // Verify slide title updated with "Modified" prefix
+    await expect(firstCard).toContainText('Modified');
+  });
+});


### PR DESCRIPTION
## Summary
- add offline handling to `tools.modify`
- provide tests for offline modify
- expose modify and save endpoints in API client
- connect wizard to backend modify API
- update edit page to await wizard changes
- add e2e test for wizard functionality

## Testing
- `POWERIT_OFFLINE=1 backend/run_tests.sh`
