### PR TITLE
Fix slide rendering by type

### DIFF
--- a/frontend/app/edit/[id]/page.tsx
+++ b/frontend/app/edit/[id]/page.tsx
@@ -1,41 +1,41 @@
-"use client"
+"use client";
 
-import { useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import { ArrowLeft, Download, Save, Loader2 } from "lucide-react"
-import type { Presentation, Slide } from "@/lib/types"
-import Link from "next/link"
-import { PatternBackground } from "@/components/ui-elements"
-import { toast } from "@/components/ui/use-toast"
-import { ToastAction } from "@/components/ui/toast"
-import WorkflowSteps from "@/components/workflow-steps"
-import ResearchStep from "@/components/steps/research-step"
-import SlidesStep from "@/components/steps/slides-step"
-import IllustrationStep from "@/components/steps/illustration-step"
-import CompiledStep from "@/components/steps/compiled-step"
-import PptxStep from "@/components/steps/pptx-step"
-import Wizard from "@/components/wizard/wizard"
-import { api } from "@/lib/api"
-import { v4 as uuidv4 } from "uuid"
-import ClientWrapper from "@/components/client-wrapper"
-import { use } from "react"
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Download, Save, Loader2 } from "lucide-react";
+import type { Presentation, Slide } from "@/lib/types";
+import Link from "next/link";
+import { PatternBackground } from "@/components/ui-elements";
+import { toast } from "@/components/ui/use-toast";
+import { ToastAction } from "@/components/ui/toast";
+import WorkflowSteps from "@/components/workflow-steps";
+import ResearchStep from "@/components/steps/research-step";
+import SlidesStep from "@/components/steps/slides-step";
+import IllustrationStep from "@/components/steps/illustration-step";
+import CompiledStep from "@/components/steps/compiled-step";
+import PptxStep from "@/components/steps/pptx-step";
+import Wizard from "@/components/wizard/wizard";
+import { api } from "@/lib/api";
+import { v4 as uuidv4 } from "uuid";
+import ClientWrapper from "@/components/client-wrapper";
+import { use } from "react";
 
 export default function EditPage({ params }: { params: { id: string } }) {
   // Properly unwrap params to get the id
   const unwrappedParams = use(params);
-  const router = useRouter()
-  const [presentation, setPresentation] = useState<Presentation | null>(null)
-  const [currentSlide, setCurrentSlide] = useState<Slide | null>(null)
-  const [currentStep, setCurrentStep] = useState(0)
-  const [isSaving, setIsSaving] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [wizardContext, setWizardContext] = useState<"all" | "single">("all")
-  const [isProcessingStep, setIsProcessingStep] = useState(false)
+  const router = useRouter();
+  const [presentation, setPresentation] = useState<Presentation | null>(null);
+  const [currentSlide, setCurrentSlide] = useState<Slide | null>(null);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [wizardContext, setWizardContext] = useState<"all" | "single">("all");
+  const [isProcessingStep, setIsProcessingStep] = useState(false);
 
-  const steps = ["Research", "Slides", "Illustration", "Compiled", "PPTX"]
-  const stepApiNames = ["research", "slides", "images", "compiled", "pptx"]
+  const steps = ["Research", "Slides", "Illustration", "Compiled", "PPTX"];
+  const stepApiNames = ["research", "slides", "images", "compiled", "pptx"];
 
   useEffect(() => {
     // Load presentation from API
@@ -47,23 +47,23 @@ export default function EditPage({ params }: { params: { id: string } }) {
     if (!presentationData.steps || !Array.isArray(presentationData.steps)) {
       return 0; // Default to first step if no steps data
     }
-    
+
     let highestCompletedStep = -1;
     for (let i = 0; i < stepApiNames.length; i++) {
       const stepName = stepApiNames[i];
       const step = presentationData.steps.find((s: any) => s.step === stepName);
-      
-      if (step && step.status === 'completed') {
+
+      if (step && step.status === "completed") {
         highestCompletedStep = i;
       } else {
         // Found first incomplete step
         break;
       }
     }
-    
+
     // If nothing is completed, start with step 0
     if (highestCompletedStep === -1) return 0;
-    
+
     // Otherwise, go to the next uncompleted step (or stay at the last step)
     return Math.min(highestCompletedStep + 1, steps.length - 1);
   };
@@ -74,12 +74,15 @@ export default function EditPage({ params }: { params: { id: string } }) {
       const fetchedPresentation = await api.getPresentation(unwrappedParams.id);
       if (fetchedPresentation) {
         setPresentation(fetchedPresentation);
-        
+
         // Determine the current step based on completion status
         const newCurrentStep = determineCurrentStep(fetchedPresentation);
         setCurrentStep(newCurrentStep);
-        
-        if (fetchedPresentation.slides && fetchedPresentation.slides.length > 0) {
+
+        if (
+          fetchedPresentation.slides &&
+          fetchedPresentation.slides.length > 0
+        ) {
           setCurrentSlide(fetchedPresentation.slides[0]);
         }
         setError(null);
@@ -100,11 +103,14 @@ export default function EditPage({ params }: { params: { id: string } }) {
 
     setIsSaving(true);
     try {
-      const updatedPresentation = await api.updatePresentation(presentation.id, presentation);
-      
+      const updatedPresentation = await api.updatePresentation(
+        presentation.id,
+        presentation,
+      );
+
       if (updatedPresentation) {
         setPresentation(updatedPresentation);
-        
+
         toast({
           title: "Changes saved",
           description: "Your presentation has been updated successfully.",
@@ -127,59 +133,63 @@ export default function EditPage({ params }: { params: { id: string } }) {
   };
 
   const addNewSlide = () => {
-    if (!presentation) return
+    if (!presentation) return;
 
     const newSlide: Slide = {
       id: uuidv4(),
+      type: "Content",
+      fields: { title: "New Slide", content: "" },
       title: "New Slide",
       content: "",
       order: presentation.slides.length,
       imagePrompt: "",
       imageUrl: "",
-    }
+    };
 
     const updatedPresentation = {
       ...presentation,
       slides: [...presentation.slides, newSlide],
-    }
+    };
 
-    setPresentation(updatedPresentation)
-    setCurrentSlide(newSlide)
-    savePresentation()
-  }
+    setPresentation(updatedPresentation);
+    setCurrentSlide(newSlide);
+    savePresentation();
+  };
 
   const updateSlide = (updatedSlide: Slide) => {
-    if (!presentation) return
+    if (!presentation) return;
 
-    const updatedSlides = presentation.slides.map((slide) => (slide.id === updatedSlide.id ? updatedSlide : slide))
+    const updatedSlides = presentation.slides.map((slide) =>
+      slide.id === updatedSlide.id ? updatedSlide : slide,
+    );
 
     setPresentation({
       ...presentation,
       slides: updatedSlides,
-    })
-    setCurrentSlide(updatedSlide)
-  }
+    });
+    setCurrentSlide(updatedSlide);
+  };
 
   const deleteSlide = (slideId: string) => {
-    if (!presentation) return
+    if (!presentation) return;
 
     const updatedSlides = presentation.slides
       .filter((slide) => slide.id !== slideId)
-      .map((slide, index) => ({ ...slide, order: index }))
+      .map((slide, index) => ({ ...slide, order: index }));
 
     const updatedPresentation = {
       ...presentation,
       slides: updatedSlides,
-    }
+    };
 
-    setPresentation(updatedPresentation)
+    setPresentation(updatedPresentation);
 
     if (currentSlide?.id === slideId) {
-      setCurrentSlide(updatedSlides.length > 0 ? updatedSlides[0] : null)
+      setCurrentSlide(updatedSlides.length > 0 ? updatedSlides[0] : null);
     }
 
-    savePresentation()
-  }
+    savePresentation();
+  };
 
   const handleExport = async () => {
     if (!presentation) return;
@@ -193,13 +203,17 @@ export default function EditPage({ params }: { params: { id: string } }) {
       // Assuming your backend endpoint for PPTX generation is '/api/generate-pptx-backend'
       // This needs to be an endpoint on your Python backend, not a Next.js API route.
       // Adjust the URL as per your actual backend API structure.
-      const response = await fetch("http://localhost:8000/api/v1/presentations/generate-pptx", { // Example backend URL
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        "http://localhost:8000/api/v1/presentations/generate-pptx",
+        {
+          // Example backend URL
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(presentation),
         },
-        body: JSON.stringify(presentation),
-      });
+      );
 
       if (!response.ok) {
         let errorData;
@@ -207,10 +221,10 @@ export default function EditPage({ params }: { params: { id: string } }) {
           errorData = await response.json();
         } catch (e) {
           // If parsing JSON fails, use text
-          errorData = { message: await response.text() || "Unknown error" };
+          errorData = { message: (await response.text()) || "Unknown error" };
         }
         throw new Error(
-          `Failed to generate PPTX: ${response.status} ${response.statusText} - ${errorData?.detail || errorData?.message || 'Server error'}`
+          `Failed to generate PPTX: ${response.status} ${response.statusText} - ${errorData?.detail || errorData?.message || "Server error"}`,
         );
       }
 
@@ -219,7 +233,9 @@ export default function EditPage({ params }: { params: { id: string } }) {
       const a = document.createElement("a");
       a.href = url;
       // Use presentation name for filename, default to 'presentation.pptx'
-      const fileName = presentation.name ? `${presentation.name.replace(/[^a-z0-9_-\s\.]/gi, '_')}.pptx` : "presentation.pptx";
+      const fileName = presentation.name
+        ? `${presentation.name.replace(/[^a-z0-9_-\s\.]/gi, "_")}.pptx`
+        : "presentation.pptx";
       a.download = fileName;
       document.body.appendChild(a);
       a.click();
@@ -235,7 +251,10 @@ export default function EditPage({ params }: { params: { id: string } }) {
       console.error("Error during PPTX export:", error);
       toast({
         title: "Export Error",
-        description: error instanceof Error ? error.message : "Failed to export PPTX. See console for details.",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to export PPTX. See console for details.",
         variant: "destructive",
         action: <ToastAction altText="OK">OK</ToastAction>,
       });
@@ -243,58 +262,59 @@ export default function EditPage({ params }: { params: { id: string } }) {
   };
 
   const handleWizardContextChange = (context: "all" | "single") => {
-    setWizardContext(context)
-  }
+    setWizardContext(context);
+  };
 
   const applyWizardChanges = async (changes: any) => {
-    if (!presentation) return
+    if (!presentation) return;
 
     if (wizardContext === "single" && currentSlide) {
       // Apply changes to current slide
-      const updatedSlide = { ...currentSlide, ...changes.slide }
-      updateSlide(updatedSlide)
+      const updatedSlide = { ...currentSlide, ...changes.slide };
+      updateSlide(updatedSlide);
     } else if (wizardContext === "all") {
       // Apply changes to all slides or presentation
       if (changes.slides) {
         setPresentation({
           ...presentation,
           slides: changes.slides,
-        })
+        });
       }
       if (changes.presentation) {
         setPresentation({
           ...presentation,
           ...changes.presentation,
-        })
+        });
       }
     }
 
-    await savePresentation()
+    await savePresentation();
 
     toast({
       title: "Changes applied",
-      description: "The suggested changes have been applied to your presentation.",
+      description:
+        "The suggested changes have been applied to your presentation.",
       action: <ToastAction altText="OK">OK</ToastAction>,
-    })
-  }
+    });
+  };
 
   // Check if a step is completed based on backend data
   const isStepCompleted = (stepIndex: number) => {
     if (!presentation || !presentation.steps) return false;
-    
+
     const stepName = stepApiNames[stepIndex];
-    const step = presentation.steps.find(s => s.step === stepName);
-    
-    return step?.status === 'completed';
+    const step = presentation.steps.find((s) => s.step === stepName);
+
+    return step?.status === "completed";
   };
 
   // Continue to next step function
   const handleContinueToNextStep = async () => {
     if (!presentation) return;
-    
+
     try {
       setIsProcessingStep(true);
-      
+
       // Get the API step name for the next uncompleted step
       let nextStepIndex = -1;
       for (let i = 0; i < stepApiNames.length; i++) {
@@ -303,30 +323,33 @@ export default function EditPage({ params }: { params: { id: string } }) {
           break;
         }
       }
-      
+
       if (nextStepIndex === -1) {
-        console.log('All steps are already completed');
+        console.log("All steps are already completed");
         setIsProcessingStep(false);
         return;
       }
-      
+
       const nextStepName = stepApiNames[nextStepIndex];
-      
+
       // Call the API to run the next step
-      const result = await api.runPresentationStep(presentation.id, nextStepName);
-      
+      const result = await api.runPresentationStep(
+        presentation.id,
+        nextStepName,
+      );
+
       if (result) {
         toast({
           title: "Step initiated",
           description: `Starting ${steps[nextStepIndex]} generation process...`,
         });
-        
+
         // Wait a bit for the step to be processed
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
         // Refresh the presentation to get updated step status
         await fetchPresentation();
-        
+
         // Move to the next step
         setCurrentStep(nextStepIndex);
       } else {
@@ -347,7 +370,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
   // Determine if continue button should be shown
   const shouldShowContinueButton = () => {
     if (!presentation || !presentation.steps) return false;
-    
+
     // Find if there are any incomplete steps
     for (let i = 0; i < stepApiNames.length; i++) {
       if (!isStepCompleted(i)) {
@@ -355,7 +378,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
         return i > 0 && isStepCompleted(i - 1);
       }
     }
-    
+
     return false; // All steps completed or no steps found
   };
 
@@ -363,19 +386,19 @@ export default function EditPage({ params }: { params: { id: string } }) {
   const handleStepChange = (stepIndex: number) => {
     // We can always navigate to current step
     if (stepIndex === currentStep) return;
-    
+
     // Allow navigation to completed steps
     if (isStepCompleted(stepIndex)) {
       setCurrentStep(stepIndex);
       return;
     }
-    
+
     // Allow navigation to the first uncompleted step (next step after completed ones)
     if (stepIndex > 0 && isStepCompleted(stepIndex - 1)) {
       setCurrentStep(stepIndex);
       return;
     }
-    
+
     // Otherwise, show error message
     toast({
       title: "Step unavailable",
@@ -385,14 +408,16 @@ export default function EditPage({ params }: { params: { id: string } }) {
   };
 
   return (
-    <ClientWrapper fallback={
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
-          <div className="h-10 w-10 rounded-full border-4 border-primary-500 border-t-transparent animate-spin"></div>
-          <p className="text-gray-600">Loading presentation...</p>
+    <ClientWrapper
+      fallback={
+        <div className="min-h-screen flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="h-10 w-10 rounded-full border-4 border-primary-500 border-t-transparent animate-spin"></div>
+            <p className="text-gray-600">Loading presentation...</p>
+          </div>
         </div>
-      </div>
-    }>
+      }
+    >
       {isLoading ? (
         <div className="min-h-screen flex items-center justify-center">
           <div className="flex flex-col items-center gap-4">
@@ -415,8 +440,12 @@ export default function EditPage({ params }: { params: { id: string } }) {
       ) : !presentation ? (
         <div className="min-h-screen flex items-center justify-center">
           <div className="text-center p-8 bg-red-50 rounded-xl border border-red-200 max-w-md">
-            <h2 className="text-xl font-semibold text-red-600 mb-4">Presentation not found</h2>
-            <p className="text-gray-600 mb-6">Unable to load the requested presentation.</p>
+            <h2 className="text-xl font-semibold text-red-600 mb-4">
+              Presentation not found
+            </h2>
+            <p className="text-gray-600 mb-6">
+              Unable to load the requested presentation.
+            </p>
             <Link href="/">
               <Button className="bg-primary hover:bg-primary-600 text-white">
                 Go to Home
@@ -440,7 +469,9 @@ export default function EditPage({ params }: { params: { id: string } }) {
                     <ArrowLeft size={18} />
                   </Button>
                 </Link>
-                <h1 className="text-2xl font-bold gradient-text">{presentation.name}</h1>
+                <h1 className="text-2xl font-bold gradient-text">
+                  {presentation.name}
+                </h1>
               </div>
               <div className="flex gap-2">
                 <Button
@@ -473,15 +504,21 @@ export default function EditPage({ params }: { params: { id: string } }) {
               </div>
             </header>
 
-            <WorkflowSteps 
-              steps={steps} 
-              currentStep={currentStep} 
-              onChange={handleStepChange} 
-              onContinue={shouldShowContinueButton() ? handleContinueToNextStep : undefined}
+            <WorkflowSteps
+              steps={steps}
+              currentStep={currentStep}
+              onChange={handleStepChange}
+              onContinue={
+                shouldShowContinueButton()
+                  ? handleContinueToNextStep
+                  : undefined
+              }
               isProcessing={isProcessingStep}
-              completedSteps={presentation?.steps ? stepApiNames.map((name, index) => 
-                isStepCompleted(index)
-              ) : []}
+              completedSteps={
+                presentation?.steps
+                  ? stepApiNames.map((name, index) => isStepCompleted(index))
+                  : []
+              }
             />
 
             <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mt-6">
@@ -535,7 +572,9 @@ export default function EditPage({ params }: { params: { id: string } }) {
                       onContextChange={handleWizardContextChange}
                     />
                   )}
-                  {currentStep === 4 && <PptxStep presentation={presentation} />}
+                  {currentStep === 4 && (
+                    <PptxStep presentation={presentation} />
+                  )}
                 </div>
               </div>
             </div>
@@ -543,5 +582,5 @@ export default function EditPage({ params }: { params: { id: string } }) {
         </div>
       )}
     </ClientWrapper>
-  )
+  );
 }

--- a/frontend/components/slide-preview.tsx
+++ b/frontend/components/slide-preview.tsx
@@ -1,24 +1,32 @@
-"use client"
+"use client";
 
-import type { Slide } from "@/lib/types"
-import { motion } from "framer-motion"
+import type { Slide } from "@/lib/types";
+import { motion } from "framer-motion";
 
 interface SlidePreviewProps {
-  slide: Slide
-  mini?: boolean
+  slide: Slide;
+  mini?: boolean;
 }
 
-export default function SlidePreview({ slide, mini = false }: SlidePreviewProps) {
+export default function SlidePreview({
+  slide,
+  mini = false,
+}: SlidePreviewProps) {
   const titleClass = mini
     ? "text-xs font-semibold mb-1"
-    : "text-3xl font-bold mb-6 bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent"
+    : "text-3xl font-bold mb-6 bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent";
 
-  const contentClass = mini ? "text-[8px] line-clamp-3" : "text-lg"
+  const contentClass = mini ? "text-[8px] line-clamp-3" : "text-lg";
 
-  const paragraphs = slide.content.split("\n").filter((p) => p.trim() !== "")
+  const paragraphs = (slide.content || "")
+    .split("\n")
+    .filter((p) => p.trim() !== "");
 
-  return (
-    <div className={`w-full h-full flex flex-col ${mini ? "" : "p-6"}`}>
+  const renderDefault = () => (
+    <div
+      className={`w-full h-full flex flex-col ${mini ? "" : "p-6"}`}
+      data-testid={mini ? undefined : "slide-preview"}
+    >
       <h3 className={titleClass}>{slide.title}</h3>
       <div className={contentClass}>
         {paragraphs.map((paragraph, index) => (
@@ -34,10 +42,82 @@ export default function SlidePreview({ slide, mini = false }: SlidePreviewProps)
         ))}
         {paragraphs.length === 0 && (
           <p className="text-gray-400 italic">
-            {mini ? "Empty slide" : "This slide is empty. Add some content in the editor."}
+            {mini
+              ? "Empty slide"
+              : "This slide is empty. Add some content in the editor."}
           </p>
         )}
       </div>
     </div>
-  )
+  );
+
+  switch (slide.type) {
+    case "Welcome":
+      return (
+        <div
+          className={`w-full h-full flex flex-col items-center justify-center ${mini ? "" : "p-6"}`}
+          data-testid={mini ? undefined : "slide-preview"}
+        >
+          <h1 className={titleClass}>{slide.fields.subtitle || slide.title}</h1>
+          {!mini && slide.fields.author && (
+            <p className="mt-2 text-sm text-gray-500">{slide.fields.author}</p>
+          )}
+        </div>
+      );
+    case "Section":
+      return (
+        <div
+          className={`w-full h-full flex items-center justify-center ${mini ? "" : "p-6"}`}
+          data-testid={mini ? undefined : "slide-preview"}
+        >
+          <h2 className={titleClass}>{slide.title}</h2>
+        </div>
+      );
+    case "TableOfContents":
+      const sections =
+        typeof slide.fields.sections === "string"
+          ? slide.fields.sections
+              .split(",")
+              .map((s: string) => s.trim())
+              .filter(Boolean)
+          : Array.isArray(slide.fields.sections)
+            ? slide.fields.sections
+            : [];
+      return (
+        <div
+          className={`w-full h-full flex flex-col ${mini ? "" : "p-6"}`}
+          data-testid={mini ? undefined : "slide-preview"}
+        >
+          <h3 className={titleClass}>Table of Contents</h3>
+          <ul className={contentClass + " list-disc ml-4"}>
+            {sections.map((sec: string, idx: number) => (
+              <li key={idx}>{sec}</li>
+            ))}
+          </ul>
+        </div>
+      );
+    case "ImageFull":
+      return (
+        <div
+          className={`w-full h-full flex flex-col items-center justify-center ${mini ? "" : "p-6"}`}
+          data-testid={mini ? undefined : "slide-preview"}
+        >
+          {slide.imageUrl && (
+            <img
+              src={slide.imageUrl}
+              className="max-h-full mb-2 object-contain"
+              alt={slide.title}
+            />
+          )}
+          <h3 className={titleClass}>{slide.title}</h3>
+          {slide.fields.explanation && !mini && (
+            <p className="mt-2 text-sm text-gray-500 text-center">
+              {slide.fields.explanation}
+            </p>
+          )}
+        </div>
+      );
+    default:
+      return renderDefault();
+  }
 }

--- a/frontend/components/steps/compiled-step.tsx
+++ b/frontend/components/steps/compiled-step.tsx
@@ -1,19 +1,20 @@
-"use client"
+"use client";
 
-import { useState } from "react"
+import { useState } from "react";
 
-import { useEffect } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { ChevronLeft, ChevronRight } from "lucide-react"
-import { motion, AnimatePresence } from "framer-motion"
-import type { Presentation, Slide } from "@/lib/types"
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { Presentation, Slide } from "@/lib/types";
+import SlidePreview from "@/components/slide-preview";
 
 interface CompiledStepProps {
-  presentation: Presentation
-  currentSlide: Slide | null
-  setCurrentSlide: (slide: Slide | null) => void
-  onContextChange: (context: "all" | "single") => void
+  presentation: Presentation;
+  currentSlide: Slide | null;
+  setCurrentSlide: (slide: Slide | null) => void;
+  onContextChange: (context: "all" | "single") => void;
 }
 
 export default function CompiledStep({
@@ -22,40 +23,51 @@ export default function CompiledStep({
   setCurrentSlide,
   onContextChange,
 }: CompiledStepProps) {
-  const [currentIndex, setCurrentIndex] = useState(0)
+  const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
     // Set context to "all" by default for the compiled view
-    onContextChange("all")
+    onContextChange("all");
 
     // If there's a current slide, find its index
     if (currentSlide) {
-      const index = presentation.slides.findIndex((slide) => slide.id === currentSlide.id)
+      const index = presentation.slides.findIndex(
+        (slide) => slide.id === currentSlide.id,
+      );
       if (index !== -1) {
-        setCurrentIndex(index)
+        setCurrentIndex(index);
       }
     }
-  }, [currentSlide, onContextChange, presentation.slides])
+  }, [currentSlide, onContextChange, presentation.slides]);
 
   const goToNextSlide = () => {
     if (currentIndex < presentation.slides.length - 1) {
-      setCurrentIndex(currentIndex + 1)
-      setCurrentSlide(presentation.slides[currentIndex + 1])
+      setCurrentIndex(currentIndex + 1);
+      setCurrentSlide(presentation.slides[currentIndex + 1]);
     }
-  }
+  };
 
   const goToPreviousSlide = () => {
     if (currentIndex > 0) {
-      setCurrentIndex(currentIndex - 1)
-      setCurrentSlide(presentation.slides[currentIndex - 1])
+      setCurrentIndex(currentIndex - 1);
+      setCurrentSlide(presentation.slides[currentIndex - 1]);
     }
-  }
+  };
 
   return (
     <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
-        <h2 className="text-2xl font-bold mb-4 gradient-text">Compiled Presentation</h2>
-        <p className="text-gray-600 mb-6">Preview your complete presentation with slides and illustrations combined.</p>
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <h2 className="text-2xl font-bold mb-4 gradient-text">
+          Compiled Presentation
+        </h2>
+        <p className="text-gray-600 mb-6">
+          Preview your complete presentation with slides and illustrations
+          combined.
+        </p>
 
         {presentation.slides.length > 0 ? (
           <div className="space-y-6">
@@ -67,39 +79,9 @@ export default function CompiledStep({
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -20 }}
                   transition={{ duration: 0.3 }}
-                  className="w-full h-full flex"
+                  className="w-full h-full"
                 >
-                  <div className="w-1/2 pr-4 flex flex-col">
-                    <h3 className="text-3xl font-bold mb-6 bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent">
-                      {presentation.slides[currentIndex].title || `Slide ${currentIndex + 1}`}
-                    </h3>
-                    <div className="text-lg flex-1 overflow-auto">
-                      {presentation.slides[currentIndex].content.split("\n").map((paragraph, index) => (
-                        <motion.p
-                          key={index}
-                          initial={{ opacity: 0, y: 10 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          transition={{ duration: 0.3, delay: index * 0.1 }}
-                          className="mb-3"
-                        >
-                          {paragraph}
-                        </motion.p>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="w-1/2 pl-4 flex items-center justify-center">
-                    {presentation.slides[currentIndex].imageUrl ? (
-                      <img
-                        src={presentation.slides[currentIndex].imageUrl || "/placeholder.svg"}
-                        alt={presentation.slides[currentIndex].title}
-                        className="max-w-full max-h-full object-contain rounded-lg shadow-md"
-                      />
-                    ) : (
-                      <div className="w-full h-full bg-gray-100 rounded-lg flex items-center justify-center text-gray-400">
-                        No image available
-                      </div>
-                    )}
-                  </div>
+                  <SlidePreview slide={presentation.slides[currentIndex]} />
                 </motion.div>
               </AnimatePresence>
 
@@ -134,29 +116,24 @@ export default function CompiledStep({
                 {presentation.slides.map((slide, index) => (
                   <Card
                     key={slide.id}
+                    data-testid={`compiled-thumbnail-${index}`}
                     className={`flex-shrink-0 w-40 cursor-pointer transition-all ${
-                      index === currentIndex ? "ring-2 ring-primary-500 scale-105" : "opacity-70 hover:opacity-100"
+                      index === currentIndex
+                        ? "ring-2 ring-primary-500 scale-105"
+                        : "opacity-70 hover:opacity-100"
                     }`}
                     onClick={() => {
-                      setCurrentIndex(index)
-                      setCurrentSlide(slide)
+                      setCurrentIndex(index);
+                      setCurrentSlide(slide);
                     }}
                   >
                     <CardContent className="p-2">
                       <div className="aspect-video bg-gray-100 rounded mb-2 overflow-hidden">
-                        {slide.imageUrl ? (
-                          <img
-                            src={slide.imageUrl || "/placeholder.svg"}
-                            alt={slide.title}
-                            className="w-full h-full object-cover"
-                          />
-                        ) : (
-                          <div className="w-full h-full flex items-center justify-center text-xs text-gray-400">
-                            No image
-                          </div>
-                        )}
+                        <SlidePreview slide={slide} mini />
                       </div>
-                      <p className="text-xs font-medium truncate">{slide.title || `Slide ${index + 1}`}</p>
+                      <p className="text-xs font-medium truncate">
+                        {slide.title || `Slide ${index + 1}`}
+                      </p>
                     </CardContent>
                   </Card>
                 ))}
@@ -165,10 +142,12 @@ export default function CompiledStep({
           </div>
         ) : (
           <div className="text-center py-12 bg-white/80 backdrop-blur-sm rounded-xl border border-gray-100">
-            <p className="text-gray-500">No slides to preview. Please create slides first.</p>
+            <p className="text-gray-500">
+              No slides to preview. Please create slides first.
+            </p>
           </div>
         )}
       </motion.div>
     </div>
-  )
+  );
 }

--- a/frontend/components/steps/slides-step.tsx
+++ b/frontend/components/steps/slides-step.tsx
@@ -1,26 +1,27 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import { useEffect } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Plus, Trash2, Sparkles, Loader2 } from "lucide-react"
-import { motion, AnimatePresence } from "framer-motion"
-import type { Presentation, Slide } from "@/lib/types"
-import { api } from "@/lib/api"
-import { toast } from "@/components/ui/use-toast"
+import { useState } from "react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Plus, Trash2, Sparkles, Loader2 } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { Presentation, Slide } from "@/lib/types";
+import SlidePreview from "@/components/slide-preview";
+import { api } from "@/lib/api";
+import { toast } from "@/components/ui/use-toast";
 
 interface SlidesStepProps {
-  presentation: Presentation
-  currentSlide: Slide | null
-  setCurrentSlide: (slide: Slide | null) => void
-  updateSlide: (slide: Slide) => void
-  addNewSlide: () => void
-  deleteSlide: (id: string) => void
-  onContextChange: (context: "all" | "single") => void
+  presentation: Presentation;
+  currentSlide: Slide | null;
+  setCurrentSlide: (slide: Slide | null) => void;
+  updateSlide: (slide: Slide) => void;
+  addNewSlide: () => void;
+  deleteSlide: (id: string) => void;
+  onContextChange: (context: "all" | "single") => void;
 }
 
 export default function SlidesStep({
@@ -32,67 +33,71 @@ export default function SlidesStep({
   deleteSlide,
   onContextChange,
 }: SlidesStepProps) {
-  const [activeTab, setActiveTab] = useState("edit")
-  const [isGenerating, setIsGenerating] = useState(false)
-  const [numSlides, setNumSlides] = useState(10) // Default number of slides to generate
+  const [activeTab, setActiveTab] = useState("edit");
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [numSlides, setNumSlides] = useState(10); // Default number of slides to generate
 
   useEffect(() => {
     // Set context to "single" when a slide is selected
     if (currentSlide) {
-      onContextChange("single")
+      onContextChange("single");
     } else {
-      onContextChange("all")
+      onContextChange("all");
     }
-  }, [currentSlide, onContextChange])
-  
+  }, [currentSlide, onContextChange]);
+
   // Function to generate slides with AI
   const handleGenerateSlides = async () => {
     try {
       setIsGenerating(true);
-      
+
       // Call the API to run the slides step
       const result = await api.runPresentationStep(presentation.id, "slides");
-      
+
       if (result) {
         toast({
           title: "Slides generation started",
-          description: "Your slides are being generated. This may take a minute..."
+          description:
+            "Your slides are being generated. This may take a minute...",
         });
-        
+
         // Poll until the slides are ready
         let slidesReady = false;
         let attempts = 0;
         const maxAttempts = 20; // Limit polling attempts
-        
+
         while (!slidesReady && attempts < maxAttempts) {
           attempts++;
-          
+
           // Wait 3 seconds between polls
-          await new Promise(resolve => setTimeout(resolve, 3000));
-          
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+
           // Fetch the updated presentation
-          const updatedPresentation = await api.getPresentation(presentation.id);
-          
+          const updatedPresentation = await api.getPresentation(
+            presentation.id,
+          );
+
           if (updatedPresentation) {
             // Check if slides step is completed
             const slidesStep = updatedPresentation.steps?.find(
-              step => step.step === "slides" && step.status === "completed"
+              (step) => step.step === "slides" && step.status === "completed",
             );
-            
+
             if (slidesStep) {
               slidesReady = true;
-              
+
               // Refresh the page to show the new slides
               window.location.reload();
             }
           }
         }
-        
+
         if (!slidesReady) {
           toast({
             title: "Taking longer than expected",
-            description: "Slides generation is still in progress. Please refresh the page in a minute.",
-            variant: "destructive"
+            description:
+              "Slides generation is still in progress. Please refresh the page in a minute.",
+            variant: "destructive",
           });
         }
       }
@@ -101,7 +106,7 @@ export default function SlidesStep({
       toast({
         title: "Error generating slides",
         description: "Failed to generate slides. Please try again.",
-        variant: "destructive"
+        variant: "destructive",
       });
     } finally {
       setIsGenerating(false);
@@ -113,19 +118,25 @@ export default function SlidesStep({
 
   return (
     <div className="space-y-6">
-      <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
         <h2 className="text-2xl font-bold mb-4 gradient-text">Slides</h2>
         <p className="text-gray-600 mb-6">
-          Create and edit your presentation slides. Add titles and content for each slide.
+          Create and edit your presentation slides. Add titles and content for
+          each slide.
         </p>
-        
+
         {noSlides ? (
           <div className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 text-center">
             <h3 className="text-xl font-semibold mb-6">Generate Slides</h3>
             <p className="text-gray-600 mb-8">
-              Your presentation needs slides. You can generate them automatically using AI based on your research.
+              Your presentation needs slides. You can generate them
+              automatically using AI based on your research.
             </p>
-            
+
             <Button
               onClick={handleGenerateSlides}
               className="bg-primary hover:bg-primary-600 text-white px-6 py-2"
@@ -150,7 +161,9 @@ export default function SlidesStep({
             {/* Slide Thumbnails */}
             <div className="lg:col-span-1 space-y-4">
               <div className="bg-white/90 backdrop-blur-sm p-4 rounded-xl shadow-sm border border-gray-100">
-                <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">Slides</h3>
+                <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+                  Slides
+                </h3>
                 <div className="space-y-3 max-h-[calc(100vh-300px)] overflow-y-auto pr-2">
                   <AnimatePresence>
                     {presentation.slides.map((slide, index) => (
@@ -162,37 +175,43 @@ export default function SlidesStep({
                         transition={{ duration: 0.2, delay: index * 0.05 }}
                       >
                         <Card
+                          data-testid={`slide-thumbnail-${index}`}
                           className={`cursor-pointer slide-card ${
-                            currentSlide?.id === slide.id ? "ring-2 ring-primary-500 bg-primary-50" : "hover:bg-gray-50"
+                            currentSlide?.id === slide.id
+                              ? "ring-2 ring-primary-500 bg-primary-50"
+                              : "hover:bg-gray-50"
                           }`}
                           onClick={() => setCurrentSlide(slide)}
                         >
                           <CardContent className="p-3">
                             <div className="flex justify-between items-center mb-2">
-                              <span className="font-medium truncate text-sm">{slide.title || `Slide ${index + 1}`}</span>
+                              <span className="font-medium truncate text-sm">
+                                {slide.title || `Slide ${index + 1}`}
+                              </span>
                               <Button
                                 variant="ghost"
                                 size="icon"
                                 className="h-6 w-6 rounded-full hover:bg-red-50 hover:text-red-500"
                                 onClick={(e) => {
-                                  e.stopPropagation()
-                                  deleteSlide(slide.id)
+                                  e.stopPropagation();
+                                  deleteSlide(slide.id);
                                 }}
                               >
                                 <Trash2 size={14} />
                               </Button>
                             </div>
-                            <div className="h-20 bg-gradient-to-br from-primary-50 to-secondary-50 rounded-lg flex items-center justify-center text-xs text-gray-500 overflow-hidden p-2">
-                              <p className="line-clamp-4 text-xs">
-                                {typeof slide.content === 'string' ? slide.content : '(No content)'}
-                              </p>
+                            <div className="h-20 bg-gradient-to-br from-primary-50 to-secondary-50 rounded-lg overflow-hidden p-2">
+                              <SlidePreview slide={slide} mini />
                             </div>
                           </CardContent>
                         </Card>
                       </motion.div>
                     ))}
                   </AnimatePresence>
-                  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+                  <motion.div
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                  >
                     <Button
                       variant="outline"
                       className="w-full flex items-center justify-center gap-1 border-dashed border-gray-300 hover:border-primary-300 hover:bg-primary-50 transition-colors"
@@ -211,7 +230,11 @@ export default function SlidesStep({
             <div className="lg:col-span-3">
               {currentSlide ? (
                 <div className="bg-white/90 backdrop-blur-sm p-6 rounded-xl shadow-sm border border-gray-100">
-                  <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+                  <Tabs
+                    value={activeTab}
+                    onValueChange={setActiveTab}
+                    className="w-full"
+                  >
                     <TabsList className="mb-6 bg-gray-100 p-1 rounded-lg">
                       <TabsTrigger
                         value="edit"
@@ -226,21 +249,50 @@ export default function SlidesStep({
                         Preview
                       </TabsTrigger>
                     </TabsList>
-                    <TabsContent value="edit" className="space-y-4 animate-fade-in">
+                    <TabsContent
+                      value="edit"
+                      className="space-y-4 animate-fade-in"
+                    >
                       <div className="space-y-2">
-                        <label className="text-sm font-medium">Slide Title</label>
+                        <label className="text-sm font-medium">
+                          Slide Title
+                        </label>
                         <Input
                           value={currentSlide.title}
-                          onChange={(e) => updateSlide({ ...currentSlide, title: e.target.value })}
+                          onChange={(e) =>
+                            updateSlide({
+                              ...currentSlide,
+                              title: e.target.value,
+                              fields: {
+                                ...currentSlide.fields,
+                                title: e.target.value,
+                              },
+                            })
+                          }
                           placeholder="Enter slide title"
                           className="text-xl font-semibold border-gray-200 focus:border-primary-300 focus:ring focus:ring-primary-200 transition-all"
                         />
                       </div>
                       <div className="space-y-2">
-                        <label className="text-sm font-medium">Slide Content</label>
+                        <label className="text-sm font-medium">
+                          Slide Content
+                        </label>
                         <Textarea
-                          value={typeof currentSlide.content === 'string' ? currentSlide.content : ''}
-                          onChange={(e) => updateSlide({ ...currentSlide, content: e.target.value })}
+                          value={
+                            typeof currentSlide.content === "string"
+                              ? currentSlide.content
+                              : ""
+                          }
+                          onChange={(e) =>
+                            updateSlide({
+                              ...currentSlide,
+                              content: e.target.value,
+                              fields: {
+                                ...currentSlide.fields,
+                                content: e.target.value,
+                              },
+                            })
+                          }
                           placeholder="Enter slide content"
                           rows={10}
                           className="resize-none border-gray-200 focus:border-primary-300 focus:ring focus:ring-primary-200 transition-all"
@@ -249,43 +301,7 @@ export default function SlidesStep({
                     </TabsContent>
                     <TabsContent value="preview" className="animate-fade-in">
                       <div className="bg-gradient-to-br from-primary-50 to-secondary-50 rounded-xl shadow-lg p-8 aspect-[16/9] flex items-center justify-center">
-                        <motion.div
-                          initial={{ opacity: 0, scale: 0.95 }}
-                          animate={{ opacity: 1, scale: 1 }}
-                          transition={{ duration: 0.3 }}
-                          className="w-full h-full"
-                        >
-                          <div className="w-full h-full flex flex-col">
-                            <h3 className="text-3xl font-bold mb-6 bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent">
-                              {currentSlide.title || "Slide Title"}
-                            </h3>
-                            <div className="text-lg">
-                              {currentSlide.content && typeof currentSlide.content === 'string' 
-                                ? currentSlide.content.split("\n").map((paragraph, index) => (
-                                    <motion.p
-                                      key={index}
-                                      initial={{ opacity: 0, y: 10 }}
-                                      animate={{ opacity: 1, y: 0 }}
-                                      transition={{ duration: 0.3, delay: index * 0.1 }}
-                                      className="mb-3"
-                                    >
-                                      {paragraph}
-                                    </motion.p>
-                                  ))
-                                : (
-                                  <p className="text-gray-400 italic">
-                                    This slide content could not be displayed properly. Please edit the slide content.
-                                  </p>
-                                )
-                              }
-                              {(!currentSlide.content) && (
-                                <p className="text-gray-400 italic">
-                                  This slide is empty. Add some content in the editor.
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        </motion.div>
+                        <SlidePreview slide={currentSlide} />
                       </div>
                     </TabsContent>
                   </Tabs>
@@ -328,5 +344,5 @@ export default function SlidesStep({
         )}
       </motion.div>
     </div>
-  )
+  );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,17 +1,17 @@
-import type { Presentation } from './types';
+import type { Presentation } from "./types";
 
 // Always use the direct backend URL to avoid redirect issues
-const API_URL = 'http://localhost:8000';
+const API_URL = "http://localhost:8000";
 
 // Helper function to ensure URL is properly formatted
 const formatImageUrl = (url: string): string => {
-  if (!url) return '';
-  
+  if (!url) return "";
+
   // If it's already an absolute URL, return it
-  if (url.startsWith('http')) return url;
-  
+  if (url.startsWith("http")) return url;
+
   // If it's a relative URL, prepend the API URL
-  return `${API_URL}${url.startsWith('/') ? '' : '/'}${url}`;
+  return `${API_URL}${url.startsWith("/") ? "" : "/"}${url}`;
 };
 
 export const api = {
@@ -19,18 +19,18 @@ export const api = {
   async getPresentations(): Promise<Presentation[]> {
     try {
       const response = await fetch(`${API_URL}/presentations`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
-        mode: 'cors',
+        mode: "cors",
       });
       if (!response.ok) {
         throw new Error(`Failed to fetch presentations: ${response.status}`);
       }
       return await response.json();
     } catch (error) {
-      console.error('Error fetching presentations:', error);
+      console.error("Error fetching presentations:", error);
       return [];
     }
   },
@@ -39,117 +39,169 @@ export const api = {
   async getPresentation(id: string): Promise<Presentation | null> {
     try {
       const response = await fetch(`${API_URL}/presentations/${id}`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
-        mode: 'cors',
+        mode: "cors",
       });
       if (!response.ok) {
         throw new Error(`Failed to fetch presentation: ${response.status}`);
       }
-      
+
       const responseData = await response.json();
-      console.log('Received presentation data:', responseData);
-      
+      console.log("Received presentation data:", responseData);
+
       // Extract slides from the steps (particularly from the 'slides' step if it exists)
       let slides: any[] = [];
       if (responseData.steps && Array.isArray(responseData.steps)) {
         // Find the slides step
         const slidesStep = responseData.steps.find(
-          (step: any) => step.step === 'slides' && step.status === 'completed' && step.result && step.result.slides
+          (step: any) =>
+            step.step === "slides" &&
+            step.status === "completed" &&
+            step.result &&
+            step.result.slides,
         );
-        
-        if (slidesStep && slidesStep.result && Array.isArray(slidesStep.result.slides)) {
-          // Convert backend slide format to frontend format
+
+        if (
+          slidesStep &&
+          slidesStep.result &&
+          Array.isArray(slidesStep.result.slides)
+        ) {
+          // Convert backend slide format to frontend format preserving type and fields
           slides = slidesStep.result.slides.map((slide: any, index: number) => {
+            const fields = slide.fields || {};
+
+            // Extract title and content in a normalized way
+            const title = fields.title || `Slide ${index + 1}`;
+            let content: any = fields.content || "";
+            if (Array.isArray(content)) {
+              content = content.join("\n");
+            } else if (typeof content !== "string") {
+              content = String(content || "");
+            }
+
+            // Attempt to get a primary image url if present in fields
+            const imageUrl = fields.image_url || slide.image_url || "";
+
             return {
               id: slide.id || `slide-${index}`,
-              title: slide.fields?.title || `Slide ${index + 1}`,
-              content: slide.fields?.content || '',
+              type: slide.type || "Content",
+              fields,
+              title,
+              content,
               order: index,
-              imagePrompt: '',
-              imageUrl: ''
+              imagePrompt: "",
+              imageUrl: imageUrl ? formatImageUrl(imageUrl) : "",
             };
           });
-          
+
           // Log slides for debugging
-          console.log('Slides after initial mapping:', slides.map(s => ({ id: s.id, title: s.title })));
+          console.log(
+            "Slides after initial mapping:",
+            slides.map((s) => ({ id: s.id, title: s.title })),
+          );
         }
-        
+
         // Find the images step and apply image URLs to slides
         const imagesStep = responseData.steps.find(
-          (step: any) => step.step === 'images' && step.status === 'completed' && step.result && Array.isArray(step.result.images)
+          (step: any) =>
+            step.step === "images" &&
+            step.status === "completed" &&
+            step.result &&
+            Array.isArray(step.result.images),
         );
-        
-        if (imagesStep && imagesStep.result && Array.isArray(imagesStep.result.images)) {
-          console.log('Found images:', imagesStep.result.images);
-          
+
+        if (
+          imagesStep &&
+          imagesStep.result &&
+          Array.isArray(imagesStep.result.images)
+        ) {
+          console.log("Found images:", imagesStep.result.images);
+
           // For each image in the backend response, update the corresponding slide
           imagesStep.result.images.forEach((image: any) => {
-            console.log('Processing image:', image);
-            
+            console.log("Processing image:", image);
+
             // Format the image URL properly
             const formattedImageUrl = formatImageUrl(image.image_url);
-            console.log('Formatted image URL:', formattedImageUrl);
-            
+            console.log("Formatted image URL:", formattedImageUrl);
+
             // Find the slide by index first (most reliable)
-            if (typeof image.slide_index === 'number' && slides[image.slide_index]) {
-              console.log(`Mapped image to slide at index ${image.slide_index}:`, slides[image.slide_index].title);
+            if (
+              typeof image.slide_index === "number" &&
+              slides[image.slide_index]
+            ) {
+              console.log(
+                `Mapped image to slide at index ${image.slide_index}:`,
+                slides[image.slide_index].title,
+              );
               slides[image.slide_index].imageUrl = formattedImageUrl;
               if (image.prompt) {
                 slides[image.slide_index].imagePrompt = image.prompt;
               }
-            } 
+            }
             // If index doesn't work, try finding by title
             else if (image.slide_title) {
               // Normalize titles for comparison
               const normalizedTitle = image.slide_title.trim();
-              
+
               // Try exact match first
-              let matchedSlide = slides.find(s => s.title === normalizedTitle);
-              
+              let matchedSlide = slides.find(
+                (s) => s.title === normalizedTitle,
+              );
+
               // If no exact match, try partial match
               if (!matchedSlide) {
-                matchedSlide = slides.find(s => 
-                  s.title.includes(normalizedTitle) || 
-                  normalizedTitle.includes(s.title)
+                matchedSlide = slides.find(
+                  (s) =>
+                    s.title.includes(normalizedTitle) ||
+                    normalizedTitle.includes(s.title),
                 );
               }
-              
+
               if (matchedSlide) {
-                console.log(`Mapped image to slide by title "${normalizedTitle}":`, matchedSlide.title);
+                console.log(
+                  `Mapped image to slide by title "${normalizedTitle}":`,
+                  matchedSlide.title,
+                );
                 matchedSlide.imageUrl = formattedImageUrl;
                 if (image.prompt) {
                   matchedSlide.imagePrompt = image.prompt;
                 }
               } else {
-                console.warn(`Could not find slide matching title: "${normalizedTitle}"`);
+                console.warn(
+                  `Could not find slide matching title: "${normalizedTitle}"`,
+                );
               }
             }
           });
-          
+
           // Debug log to see mappings
-          console.log('Slides with mapped images:', slides.map(s => ({ 
-            title: s.title, 
-            hasImage: !!s.imageUrl,
-            imageUrl: s.imageUrl
-          })));
+          console.log(
+            "Slides with mapped images:",
+            slides.map((s) => ({
+              title: s.title,
+              hasImage: !!s.imageUrl,
+              imageUrl: s.imageUrl,
+            })),
+          );
         }
       }
-      
+
       // Map backend response to frontend model
       return {
         id: responseData.id.toString(),
         name: responseData.name,
-        author: responseData.author || '',
-        researchMethod: 'ai', // Default to AI, can be updated later if needed
-        topic: responseData.topic || '',
-        manualResearch: responseData.research_content || '',
+        author: responseData.author || "",
+        researchMethod: "ai", // Default to AI, can be updated later if needed
+        topic: responseData.topic || "",
+        manualResearch: responseData.research_content || "",
         slides: slides,
         steps: responseData.steps,
         createdAt: responseData.created_at,
-        updatedAt: responseData.updated_at
+        updatedAt: responseData.updated_at,
       };
     } catch (error) {
       console.error(`Error fetching presentation ${id}:`, error);
@@ -158,96 +210,107 @@ export const api = {
   },
 
   // Create a new presentation
-  async createPresentation(presentation: Omit<Presentation, 'id' | 'createdAt' | 'updatedAt'>): Promise<Presentation | null> {
+  async createPresentation(
+    presentation: Omit<Presentation, "id" | "createdAt" | "updatedAt">,
+  ): Promise<Presentation | null> {
     try {
       // Map frontend model to backend model
       const backendPresentationData: Record<string, any> = {
         name: presentation.name,
         author: presentation.author,
-        research_type: presentation.researchMethod === 'ai' ? 'research' : 'manual_research',
+        research_type:
+          presentation.researchMethod === "ai" ? "research" : "manual_research",
       };
-      
+
       // Add the appropriate research fields based on research type
-      if (presentation.researchMethod === 'ai') {
+      if (presentation.researchMethod === "ai") {
         backendPresentationData.topic = presentation.topic;
       } else {
         backendPresentationData.research_content = presentation.manualResearch;
       }
-      
-      console.log('Sending presentation data to API:', JSON.stringify(backendPresentationData));
-      
+
+      console.log(
+        "Sending presentation data to API:",
+        JSON.stringify(backendPresentationData),
+      );
+
       const response = await fetch(`${API_URL}/presentations`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(backendPresentationData),
       });
-      
+
       const responseData = await response.json();
-      
+
       if (!response.ok) {
         // Enhanced error handling with detailed error information
         console.error(`Server error ${response.status}:`, responseData);
-        
+
         let errorMessage = "Failed to create presentation";
-        
+
         // If we have a detailed error message from the API, use it
         if (responseData && responseData.detail) {
           errorMessage = responseData.detail;
-          
+
           // Attach additional error information if available
           if (responseData.error_type) {
             const errorDetails = {
-              ...responseData
+              ...responseData,
             };
-            
-            throw new Error(JSON.stringify({
-              message: errorMessage,
-              details: errorDetails
-            }));
+
+            throw new Error(
+              JSON.stringify({
+                message: errorMessage,
+                details: errorDetails,
+              }),
+            );
           }
         }
-        
+
         throw new Error(errorMessage);
       }
-      
-      console.log('Received response:', responseData);
-      
+
+      console.log("Received response:", responseData);
+
       // Map backend response to frontend model
       return {
         id: responseData.id.toString(),
         name: responseData.name,
-        author: responseData.author || '',
+        author: responseData.author || "",
         researchMethod: presentation.researchMethod, // Use the original value from frontend
-        topic: responseData.topic || '',
-        manualResearch: responseData.research_content || '',
+        topic: responseData.topic || "",
+        manualResearch: responseData.research_content || "",
         slides: [], // Always initialize slides as empty array
         createdAt: responseData.created_at,
-        updatedAt: responseData.updated_at
+        updatedAt: responseData.updated_at,
       };
     } catch (error) {
-      console.error('Error creating presentation:', error);
+      console.error("Error creating presentation:", error);
       throw error; // Re-throw to allow the component to handle the error
     }
   },
-  
+
   // Update an existing presentation
-  async updatePresentation(id: string, presentation: Partial<Presentation>): Promise<Presentation | null> {
+  async updatePresentation(
+    id: string,
+    presentation: Partial<Presentation>,
+  ): Promise<Presentation | null> {
     try {
       const response = await fetch(`${API_URL}/presentations/${id}/modify`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(presentation),
-        mode: 'cors',
+        mode: "cors",
       });
-      
+
       if (!response.ok) {
         throw new Error(`Failed to update presentation: ${response.status}`);
       }
-      
+
       return await response.json();
     } catch (error) {
       console.error(`Error updating presentation ${id}:`, error);
@@ -256,52 +319,66 @@ export const api = {
   },
 
   // Request AI modifications for a slide or presentation
-  async modifyPresentation(id: string | number, prompt: string, slideIndex?: number, currentStep?: string): Promise<any> {
-    const payload: any = { prompt }
-    if (typeof slideIndex === 'number') payload.slide_index = slideIndex
-    if (currentStep) payload.current_step = currentStep
+  async modifyPresentation(
+    id: string | number,
+    prompt: string,
+    slideIndex?: number,
+    currentStep?: string,
+  ): Promise<any> {
+    const payload: any = { prompt };
+    if (typeof slideIndex === "number") payload.slide_index = slideIndex;
+    if (currentStep) payload.current_step = currentStep;
 
     const response = await fetch(`${API_URL}/presentations/${id}/modify`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
-      mode: 'cors'
-    })
+      mode: "cors",
+    });
 
     if (!response.ok) {
-      throw new Error(`Failed to modify presentation: ${response.status}`)
+      throw new Error(`Failed to modify presentation: ${response.status}`);
     }
 
-    return await response.json()
+    return await response.json();
   },
 
   // Save modified presentation data back to the server
-  async saveModifiedPresentation(id: string | number, data: any): Promise<boolean> {
-    const response = await fetch(`${API_URL}/presentations/${id}/save_modified`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-      mode: 'cors'
-    })
+  async saveModifiedPresentation(
+    id: string | number,
+    data: any,
+  ): Promise<boolean> {
+    const response = await fetch(
+      `${API_URL}/presentations/${id}/save_modified`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+        mode: "cors",
+      },
+    );
 
-    return response.ok
+    return response.ok;
   },
 
   // Run a specific step for a presentation
   async runPresentationStep(id: string, step: string): Promise<any> {
     try {
-      const response = await fetch(`${API_URL}/presentations/${id}/steps/${step}/run`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        `${API_URL}/presentations/${id}/steps/${step}/run`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          mode: "cors",
         },
-        mode: 'cors',
-      });
-      
+      );
+
       if (!response.ok) {
         throw new Error(`Failed to run step: ${response.status}`);
       }
-      
+
       return await response.json();
     } catch (error) {
       console.error(`Error running step for presentation ${id}:`, error);
@@ -313,14 +390,14 @@ export const api = {
   async deletePresentation(id: string): Promise<boolean> {
     try {
       const response = await fetch(`${API_URL}/presentations/${id}`, {
-        method: 'DELETE',
-        mode: 'cors',
+        method: "DELETE",
+        mode: "cors",
       });
-      
+
       return response.ok;
     } catch (error) {
       console.error(`Error deleting presentation ${id}:`, error);
       return false;
     }
-  }
-}; 
+  },
+};

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,15 +1,27 @@
 export interface Slide {
-  id: string
-  title: string
-  content: string
-  order: number
-  imagePrompt?: string
-  imageUrl?: string
+  id: string;
+  /** Raw slide type from the backend (e.g. Welcome, ContentImage) */
+  type: string;
+  /** Original fields object returned by the API */
+  fields: Record<string, any>;
+  /** Convenience title extracted from fields */
+  title: string;
+  /** Convenience content (joined if array) */
+  content: string;
+  order: number;
+  imagePrompt?: string;
+  imageUrl?: string;
 }
 
 export interface PresentationStep {
   id: number;
-  step: "research" | "manual_research" | "slides" | "images" | "compiled" | "pptx";
+  step:
+    | "research"
+    | "manual_research"
+    | "slides"
+    | "images"
+    | "compiled"
+    | "pptx";
   status: "pending" | "running" | "completed" | "error";
   result?: Record<string, any> | null;
   error_message?: string | null;
@@ -22,10 +34,10 @@ export interface Presentation {
   name: string; // Changed from title to name to match backend
   author?: string; // Made optional to match backend
   researchMethod?: "ai" | "manual"; // Keep for frontend logic, though backend uses step type
-  topic?: string
-  manualResearch?: string // This can be deprecated if research content is always in steps
-  slides: Slide[]
+  topic?: string;
+  manualResearch?: string; // This can be deprecated if research content is always in steps
+  slides: Slide[];
   steps?: PresentationStep[]; // Add steps array
-  createdAt: string
-  updatedAt: string
+  createdAt: string;
+  updatedAt: string;
 }

--- a/testing/e2e/slides-display.spec.ts
+++ b/testing/e2e/slides-display.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+import { createPresentation, runStepAndWaitForCompletion } from "./utils";
+
+test.setTimeout(120000);
+
+test.describe("Slides Display", () => {
+  test("generated slides are shown with content", async ({ page }) => {
+    const name = `Slides Display ${Date.now()}`;
+    const topic = "Offline slide topic";
+
+    await createPresentation(page, name, topic);
+    await runStepAndWaitForCompletion(page, "slides");
+
+    // Wait for first thumbnail and open it
+    const firstThumb = page.getByTestId("slide-thumbnail-0");
+    await firstThumb.waitFor({ timeout: 10000 });
+    await firstThumb.click();
+
+    // Check that welcome subtitle text from offline fixture is visible
+    await expect(page.getByTestId("slide-preview")).toContainText(
+      "Transforming Industries Through Innovation",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- preserve slide type and fields when loading slides
- render slides based on their type in SlidePreview
- show previews in Slides and Compiled steps using SlidePreview
- update slide editing logic to keep field values
- add e2e test checking slide content display

## Testing
- `npm --prefix testing test e2e/slides-display.spec.ts` *(fails: ECONNREFUSED)*