### PR TITLE
Add delete confirmation

### DIFF
--- a/frontend/components/presentation-list.tsx
+++ b/frontend/components/presentation-list.tsx
@@ -36,6 +36,8 @@ export default function PresentationList() {
   }
 
   const handleDelete = async (id: string) => {
+    if (!window.confirm("Are you sure")) return
+
     try {
       const success = await api.deletePresentation(id)
 

--- a/testing/e2e/delete-presentation.spec.ts
+++ b/testing/e2e/delete-presentation.spec.ts
@@ -14,6 +14,12 @@ test.describe('Delete Presentation', () => {
     const card = page.getByTestId(`presentation-card-${id}`);
     await expect(card).toBeVisible();
 
+    // Accept the confirmation dialog
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Are you sure');
+      await dialog.accept();
+    });
+
     await card.getByTestId('delete-presentation-button').click();
 
     await expect(card).not.toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Summary
- ask users for confirmation before deleting presentations
- handle confirmation dialog in delete presentation E2E test

## Testing
- `npm test` *(fails: connection refused)*