### PR TITLE
Separate DB for tests and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ backend/presentations_backup.txt
 storage/presentations/
 temp_pptx/
 backend/storage/presentations/
+backend/tests/output/
 
 # Ignore environment and config files
 .env*

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,13 +5,25 @@ from datetime import datetime, timezone
 import enum
 import json
 import os
+from dotenv import load_dotenv
 
 # Helper function to get current UTC time
 def utc_now():
     return datetime.now(timezone.utc)
 
+# Load environment variables
+load_dotenv()
+
+# Determine which database file to use
+DATABASE_FILE = os.getenv("DATABASE_FILE", "presentations.db")
+TEST_DATABASE_FILE = os.getenv("TEST_DATABASE_FILE", "presentations_test.db")
+ENVIRONMENT = os.getenv("POWERIT_ENV", "production")
+
+db_file = TEST_DATABASE_FILE if ENVIRONMENT == "test" else DATABASE_FILE
+db_path = db_file if os.path.isabs(db_file) else os.path.join(os.path.dirname(__file__), db_file)
+
 # Create async engine
-SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///./presentations.db"
+SQLALCHEMY_DATABASE_URL = f"sqlite+aiosqlite:///{db_path}"
 engine = create_async_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 

--- a/backend/run_tests.sh
+++ b/backend/run_tests.sh
@@ -16,11 +16,16 @@ else
 fi
 
 # Run tests with specified arguments or all tests if none provided
+# Ensure test environment variables
+export POWERIT_ENV=test
+# Use dedicated test database file if provided
+export DATABASE_FILE="${TEST_DATABASE_FILE:-${DATABASE_FILE:-presentations_test.db}}"
+
 if [ $# -eq 0 ]; then
-    # Run all tests with the POWERIT_OFFLINE=true environment variable for offline testing
+    # Run all tests with offline mode enabled
     POWERIT_OFFLINE=true python -m pytest tests/ -v
 else
-    # Run specific test file or with specific options with the POWERIT_OFFLINE=true environment variable
+    # Run specific test file or with specific options
     POWERIT_OFFLINE=true python -m pytest "$@"
 fi
 


### PR DESCRIPTION
## Summary
- add env-aware DB configuration
- run backend tests with dedicated DB
- store logo tester output in ignored folder
- ignore backend test output folder

## Testing
- `BACKEND_DIR=backend make test-backend`