### PR TITLE
Add research modification support

### DIFF
--- a/backend/routers/presentations.py
+++ b/backend/routers/presentations.py
@@ -36,6 +36,7 @@ from services import (
     execute_topic_update_task
 )
 from tools.images import generate_image_from_prompt
+from tools.modify import modify_research
 from config import PRESENTATIONS_STORAGE_DIR
 
 router = APIRouter(
@@ -789,6 +790,74 @@ async def modify_presentation_endpoint(
             status_code=500,
             content={"detail": f"Error processing request: {str(e)}"},
         )
+
+
+@router.post("/{presentation_id}/research/modify",
+           summary="Modify research",
+           description="Modify research content using AI based on user instructions")
+async def modify_research_endpoint(
+    presentation_id: int,
+    request: Request
+):
+    """Return modified research without saving it."""
+    try:
+        data = await request.json()
+        prompt = data.get("prompt")
+        if not prompt:
+            return JSONResponse(status_code=400, content={"detail": "Missing prompt"})
+
+        async with SessionLocal() as db:
+            step_result = await db.execute(
+                select(PresentationStepModel).filter(
+                    PresentationStepModel.presentation_id == presentation_id,
+                    PresentationStepModel.step.in_([
+                        PresentationStep.RESEARCH.value,
+                        PresentationStep.MANUAL_RESEARCH.value,
+                    ])
+                )
+            )
+            research_step = step_result.scalars().first()
+
+            if not research_step or research_step.status != StepStatus.COMPLETED.value:
+                return JSONResponse(status_code=400, content={"detail": "Research step not completed"})
+
+            research_data = research_step.get_result()
+            modified = await modify_research(research_data, prompt)
+            return JSONResponse(status_code=200, content=modified.model_dump())
+
+    except Exception as e:
+        import traceback
+        print("Error modifying research", e)
+        print(traceback.format_exc())
+        return JSONResponse(status_code=500, content={"detail": f"Error modifying research: {str(e)}"})
+
+
+@router.post("/{presentation_id}/save_modified_research",
+           summary="Save modified research",
+           description="Persist modified research data to the research step")
+async def save_modified_research(
+    presentation_id: int,
+    modified_data: Dict[str, Any],
+    db: AsyncSession = Depends(get_db),
+):
+    step_result = await db.execute(
+        select(PresentationStepModel).filter(
+            PresentationStepModel.presentation_id == presentation_id,
+            PresentationStepModel.step.in_([
+                PresentationStep.RESEARCH.value,
+                PresentationStep.MANUAL_RESEARCH.value,
+            ])
+        )
+    )
+    step = step_result.scalars().first()
+    if not step:
+        raise HTTPException(status_code=404, detail="Research step not found")
+
+    step.set_result(modified_data)
+    step.status = StepStatus.COMPLETED.value
+    await db.commit()
+
+    return {"message": f"Modified research saved for presentation {presentation_id}", "presentation_id": presentation_id}
 
 @router.post("/{presentation_id}/slides/{slide_index}/image",
            summary="Regenerate slide image",

--- a/frontend/app/edit/[id]/page.tsx
+++ b/frontend/app/edit/[id]/page.tsx
@@ -22,6 +22,10 @@ import ClientWrapper from "@/components/client-wrapper";
 import { use } from "react";
 import React from "react";
 
+// Move constants outside component to prevent re-creation on every render
+const STEPS = ["Research", "Slides", "Illustration", "Compiled", "PPTX"];
+const STEP_API_NAMES = ["research", "slides", "images", "compiled", "pptx"];
+
 export default function EditPage({ params }: { params: { id: string } }) {
   // Properly unwrap params to get the id
   const unwrappedParams = React.use(params);
@@ -38,9 +42,6 @@ export default function EditPage({ params }: { params: { id: string } }) {
   const [error, setError] = useState<string | null>(null);
   const [wizardContext, setWizardContext] = useState<"all" | "single">("all");
   const [isProcessingStep, setIsProcessingStep] = useState(false);
-
-  const steps = ["Research", "Slides", "Illustration", "Compiled", "PPTX"];
-  const stepApiNames = ["research", "slides", "images", "compiled", "pptx"];
 
   // Helper for structured logging
   const logInfo = (message: string, data?: any) => {
@@ -177,8 +178,8 @@ export default function EditPage({ params }: { params: { id: string } }) {
     }
 
     let highestCompletedStep = -1;
-    for (let i = 0; i < stepApiNames.length; i++) {
-      const stepName = stepApiNames[i];
+    for (let i = 0; i < STEP_API_NAMES.length; i++) {
+      const stepName = STEP_API_NAMES[i];
       const step = presentationData.steps.find((s: any) => s.step === stepName);
 
       if (step && step.status === "completed") {
@@ -453,7 +454,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
   const isStepCompleted = (stepIndex: number) => {
     if (!presentation || !presentation.steps) return false;
 
-    const stepName = stepApiNames[stepIndex];
+    const stepName = STEP_API_NAMES[stepIndex];
     const step = presentation.steps.find((s) => s.step === stepName);
 
     // Debug logging to understand what's happening
@@ -472,7 +473,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
   const isStepPending = (stepIndex: number) => {
     if (!presentation || !presentation.steps) return false;
 
-    const stepName = stepApiNames[stepIndex];
+    const stepName = STEP_API_NAMES[stepIndex];
     const step = presentation.steps.find((s) => s.step === stepName);
 
     return step?.status === "pending";
@@ -482,7 +483,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
   const isStepProcessing = (stepIndex: number) => {
     if (!presentation || !presentation.steps) return false;
 
-    const stepName = stepApiNames[stepIndex];
+    const stepName = STEP_API_NAMES[stepIndex];
     const step = presentation.steps.find((s) => s.step === stepName);
 
     return step?.status === "running";
@@ -492,40 +493,40 @@ export default function EditPage({ params }: { params: { id: string } }) {
   const completedSteps = useMemo(() => {
     if (!presentation?.steps) return [];
     
-    const completed = stepApiNames.map((name, index) => isStepCompleted(index));
+    const completed = STEP_API_NAMES.map((name, index) => isStepCompleted(index));
     logInfo('🔄 Completed steps array updated:', completed.map((isCompleted, index) => ({
-      step: stepApiNames[index],
+      step: STEP_API_NAMES[index],
       completed: isCompleted
     })));
     
     return completed;
-  }, [presentation?.steps, stepApiNames]);
+  }, [presentation?.steps]);
 
   // Memoize the pending steps array
   const pendingSteps = useMemo(() => {
     if (!presentation?.steps) return [];
     
-    const pending = stepApiNames.map((name, index) => isStepPending(index));
+    const pending = STEP_API_NAMES.map((name, index) => isStepPending(index));
     logInfo('🔄 Pending steps array updated:', pending.map((isPending, index) => ({
-      step: stepApiNames[index],
+      step: STEP_API_NAMES[index],
       pending: isPending
     })));
     
     return pending;
-  }, [presentation?.steps, stepApiNames]);
+  }, [presentation?.steps]);
 
   // Memoize the processing steps array
   const processSteps = useMemo(() => {
     if (!presentation?.steps) return [];
     
-    const processing = stepApiNames.map((name, index) => isStepProcessing(index));
+    const processing = STEP_API_NAMES.map((name, index) => isStepProcessing(index));
     logInfo('🔄 Processing steps array updated:', processing.map((isProcessing, index) => ({
-      step: stepApiNames[index],
+      step: STEP_API_NAMES[index],
       processing: isProcessing
     })));
     
     return processing;
-  }, [presentation?.steps, stepApiNames]);
+  }, [presentation?.steps]);
 
   // Continue to next step function
   const handleContinueToNextStep = async () => {
@@ -536,7 +537,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
 
       // Get the API step name for the next uncompleted step
       let nextStepIndex = -1;
-      for (let i = 0; i < stepApiNames.length; i++) {
+      for (let i = 0; i < STEP_API_NAMES.length; i++) {
         if (!isStepCompleted(i)) {
           nextStepIndex = i;
           break;
@@ -549,7 +550,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
         return;
       }
 
-      const nextStepName = stepApiNames[nextStepIndex];
+      const nextStepName = STEP_API_NAMES[nextStepIndex];
 
       // Call the API to run the next step
       const result = await api.runPresentationStep(
@@ -560,7 +561,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
       if (result) {
         toast({
           title: "Step initiated",
-          description: `Starting ${steps[nextStepIndex]} generation process...`,
+          description: `Starting ${STEPS[nextStepIndex]} generation process...`,
         });
 
         // Wait a bit for the step to be processed
@@ -591,7 +592,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
     if (!presentation || !presentation.steps) return false;
 
     // Find if there are any incomplete steps
-    for (let i = 0; i < stepApiNames.length; i++) {
+    for (let i = 0; i < STEP_API_NAMES.length; i++) {
       if (!isStepCompleted(i)) {
         // If the step before this one is completed, we show the continue button
         return i > 0 && isStepCompleted(i - 1);
@@ -744,7 +745,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
             </header>
 
             <WorkflowSteps
-              steps={steps}
+              steps={STEPS}
               currentStep={currentStep}
               onChange={handleStepChange}
               onContinue={
@@ -765,7 +766,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
                   presentation={presentation}
                   currentSlide={currentSlide}
                   context={wizardContext}
-                  step={steps[currentStep]}
+                  step={STEPS[currentStep]}
                   onApplyChanges={applyWizardChanges}
                 />
               </div>

--- a/frontend/app/edit/[id]/page.tsx
+++ b/frontend/app/edit/[id]/page.tsx
@@ -415,6 +415,16 @@ export default function EditPage({ params }: { params: { id: string } }) {
           ...changes.presentation,
         });
       }
+      if (changes.research) {
+        const updatedSteps = presentation.steps?.map(s =>
+          s.step === "research" || s.step === "manual_research"
+            ? { ...s, result: changes.research, status: "completed" }
+            : s
+        ) || [];
+
+        setPresentation({ ...presentation, steps: updatedSteps });
+        await api.saveModifiedResearch(presentation.id, changes.research);
+      }
     }
 
     await savePresentation();

--- a/frontend/components/wizard/wizard-suggestion.tsx
+++ b/frontend/components/wizard/wizard-suggestion.tsx
@@ -62,7 +62,7 @@ export default function WizardSuggestion({
   }
 
   return (
-    <div className="border border-primary-200 rounded-lg p-4 bg-primary-50">
+    <div className="border border-primary-200 rounded-lg p-4 bg-primary-50" data-testid="wizard-suggestion">
       <div className="mb-3">
         <div className="flex items-center justify-between mb-2">
           <h4 className="font-medium text-primary-700">Suggested Changes</h4>
@@ -255,6 +255,7 @@ export default function WizardSuggestion({
             size="sm"
             className="flex items-center gap-1 hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
             onClick={onDismiss}
+            data-testid="wizard-dismiss-button"
           >
             <X size={14} />
             Dismiss
@@ -264,6 +265,7 @@ export default function WizardSuggestion({
             className="bg-primary hover:bg-primary-600 text-white flex items-center gap-1 disabled:opacity-50"
             onClick={onApply}
             disabled={!hasChanges()}
+            data-testid="wizard-apply-button"
           >
             <Check size={14} />
             Apply Changes

--- a/frontend/components/wizard/wizard-suggestion.tsx
+++ b/frontend/components/wizard/wizard-suggestion.tsx
@@ -23,6 +23,7 @@ export default function WizardSuggestion({
   const [showPreview, setShowPreview] = useState(false)
   const isSingleSlide = context === "single" && suggestion.slide
   const isAllSlides = context === "all" && suggestion.slides
+  const isResearch = !!suggestion.research
 
   const hasChanges = () => {
     if (isSingleSlide && currentSlide) {
@@ -157,6 +158,15 @@ export default function WizardSuggestion({
                   ...and {suggestion.slides.length - 5} more slides
                 </div>
               )}
+            </div>
+          </div>
+        )}
+
+        {isResearch && (
+          <div>
+            <p className="text-gray-700 mb-2 font-medium">Updated Research:</p>
+            <div className="bg-gray-50 rounded p-2 text-sm whitespace-pre-wrap max-h-60 overflow-y-auto">
+              {suggestion.research.content}
             </div>
           </div>
         )}

--- a/frontend/components/wizard/wizard.tsx
+++ b/frontend/components/wizard/wizard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -45,6 +45,10 @@ export default function Wizard({ presentation, currentSlide, context, step, onAp
     scrollToBottom()
   }, [messages])
 
+  // Memoize currentSlide properties to prevent unnecessary re-renders
+  const currentSlideId = useMemo(() => currentSlide?.id, [currentSlide?.id])
+  const currentSlideTitle = useMemo(() => currentSlide?.title, [currentSlide?.title])
+
   // Update welcome message when step, context, or currentSlide changes
   useEffect(() => {
     const getWelcomeMessage = () => {
@@ -76,7 +80,7 @@ export default function Wizard({ presentation, currentSlide, context, step, onAp
     
     setMessages([welcomeMessage])
     setError(null)
-  }, [step, context, currentSlide])
+  }, [step, context, currentSlideId, currentSlideTitle])
 
   const updateMessageStatus = (messageIndex: number, status: MessageStatus) => {
     setMessages(prev => prev.map((msg, idx) => 
@@ -283,20 +287,7 @@ export default function Wizard({ presentation, currentSlide, context, step, onAp
       setMessages(prev => [...prev, successMessage])
     }
   }
-          
-          
-const successMessage: Message = {
-  role: "assistant",
-  content: step === "Research"
-    ? "Great! The research has been updated with the suggested changes."
-    : suggestion.presentation
-      ? "Perfect! I've successfully applied the changes to your presentation. The modifications should now be visible in the slide editor."
-      : "Perfect! I've successfully applied the changes to your slide. The improvements should now be visible in the slide editor.",
-  status: "success",
-  timestamp: new Date()
-};
 
-setMessages(prev => [...prev, successMessage]);
 
   const dismissSuggestion = () => {
     setSuggestion(null)

--- a/frontend/components/wizard/wizard.tsx
+++ b/frontend/components/wizard/wizard.tsx
@@ -156,7 +156,19 @@ export default function Wizard({ presentation, currentSlide, context, step, onAp
           }
         }
       } else if (step === "Research") {
-        response = "I can help you with research questions and provide guidance on research methods. However, slide content modification is only available in the Slides step after you've generated slides.";
+        try {
+          const apiResp = await api.modifyResearch(presentation.id, input);
+          if (apiResp && apiResp.content) {
+            response = "I've prepared updated research content. You can apply the changes below.";
+            suggestedChanges = { research: apiResp };
+          } else {
+            response = "I've processed your request, but no specific changes were suggested.";
+          }
+        } catch (error) {
+          console.error("Error modifying research:", error);
+          response = "I encountered an error while trying to modify the research.";
+          setError("Failed to process research modification. Please try again.");
+        }
       } else if (step === "Illustrations") {
         response = "I can help with image suggestions and visual improvements. For slide content changes, please use the Slides step.";
       } else if (step === "PPTX") {
@@ -194,10 +206,12 @@ export default function Wizard({ presentation, currentSlide, context, step, onAp
     if (suggestion) {
       onApplyChanges(suggestion)
       setSuggestion(null)
-      
+
       const successMessage: Message = {
         role: "assistant",
-        content: "Perfect! I've successfully applied the changes to your slide. The improvements should now be visible in the slide editor.",
+        content: step === "Research"
+          ? "Great! The research has been updated with the suggested changes."
+          : "Perfect! I've successfully applied the changes to your slide. The improvements should now be visible in the slide editor.",
         status: "success",
         timestamp: new Date()
       }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -346,6 +346,41 @@ export const api = {
     return await response.json();
   },
 
+  async modifyResearch(id: string | number, prompt: string): Promise<any> {
+    const response = await fetch(
+      `${API_URL}/presentations/${id}/research/modify`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+        mode: "cors",
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to modify research: ${response.status}`);
+    }
+
+    return await response.json();
+  },
+
+  async saveModifiedResearch(
+    id: string | number,
+    data: any
+  ): Promise<boolean> {
+    const response = await fetch(
+      `${API_URL}/presentations/${id}/save_modified_research`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+        mode: "cors",
+      }
+    );
+
+    return response.ok;
+  },
+
   async saveModifiedPresentation(
     id: string | number,
     data: any

--- a/testing/e2e/debug-research-page.spec.ts
+++ b/testing/e2e/debug-research-page.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { navigateToEditPage } from './utils';
+
+test.describe('Debug Research Page', () => {
+  test('debug research page state', async ({ page }) => {
+    // Navigate directly to create page and create presentation manually
+    await page.goto('http://localhost:3000/create');
+    
+    // Fill out the basic form
+    const uniqueName = `Debug Test ${Date.now()}`;
+    await page.getByTestId('presentation-title-input').fill(uniqueName);
+    await page.getByTestId('presentation-author-input').fill('Test Author');
+    
+    // Submit the form
+    await page.getByTestId('submit-presentation-button').click();
+    
+    // Wait for navigation to edit page
+    await expect(page).toHaveURL(/\/edit\/\d+/, { timeout: 15000 });
+    
+    // Check if method selection is visible
+    const methodSelection = page.locator('[data-testid="research-method-selection"]');
+    if (await methodSelection.isVisible()) {
+      console.log('Method selection is visible, proceeding with selection...');
+      
+      // Select AI research method
+      await page.getByTestId('ai-research-option').click();
+      
+      // Wait for continue button and click it
+      const continueButton = page.getByTestId('continue-with-method-button');
+      await expect(continueButton).toBeEnabled();
+      await continueButton.click();
+      
+      // Wait for method selection to disappear
+      await expect(methodSelection).not.toBeVisible({ timeout: 10000 });
+      
+      // Wait for AI research interface
+      await expect(page.getByTestId('ai-research-interface')).toBeVisible({ timeout: 10000 });
+      
+      // Fill in topic
+      await page.getByTestId('topic-input').fill('Test Topic');
+      
+      console.log('✅ Successfully navigated to AI research interface');
+    }
+    
+    // Take a screenshot to see what's on the page
+    await page.screenshot({ path: 'debug-research-page.png', fullPage: true });
+    
+    // Log all elements with data-testid
+    const testIds = await page.locator('[data-testid]').all();
+    console.log('Found elements with data-testid:');
+    for (const element of testIds) {
+      const testId = await element.getAttribute('data-testid');
+      const isVisible = await element.isVisible();
+      console.log(`- ${testId}: ${isVisible ? 'visible' : 'hidden'}`);
+    }
+    
+    // Check if we're in the right state
+    const aiInterface = page.locator('[data-testid="ai-research-interface"]');
+    const manualInterface = page.locator('[data-testid="manual-research-interface"]');
+    const methodSelectionFinal = page.locator('[data-testid="research-method-selection"]');
+    
+    console.log('Interface states:');
+    console.log(`- AI interface visible: ${await aiInterface.isVisible()}`);
+    console.log(`- Manual interface visible: ${await manualInterface.isVisible()}`);
+    console.log(`- Method selection visible: ${await methodSelectionFinal.isVisible()}`);
+    
+    // Check for buttons
+    const startButton = page.locator('[data-testid="start-ai-research-button"]');
+    const updateButton = page.locator('[data-testid="update-research-button"]');
+    
+    console.log('Button states:');
+    console.log(`- Start button visible: ${await startButton.isVisible()}`);
+    console.log(`- Update button visible: ${await updateButton.isVisible()}`);
+    
+    // Check topic input
+    const topicInput = page.locator('[data-testid="topic-input"]');
+    console.log(`- Topic input visible: ${await topicInput.isVisible()}`);
+    if (await topicInput.isVisible()) {
+      const topicValue = await topicInput.inputValue();
+      console.log(`- Topic value: "${topicValue}"`);
+    }
+  });
+}); 

--- a/testing/e2e/research-wizard-suggestions.spec.ts
+++ b/testing/e2e/research-wizard-suggestions.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test';
+import { 
+  createPresentation, 
+  waitForStepCompletion, 
+  navigateToEditPage,
+  fillResearchTopic,
+  startAIResearch,
+  waitForResearchCompletion
+} from './utils';
+
+test.describe('Research Wizard Suggestions', () => {
+  test('should allow wizard to modify research content with suggestions', async ({ page }) => {
+    // Create a new presentation for testing (this also sets up the AI research interface)
+    const presentationId = await createPresentation(page, 'Research Wizard Suggestions Test', 'Artificial Intelligence in Healthcare: Current Applications and Future Trends');
+    
+    // Verify we're on the Research step and AI interface is ready
+    await expect(page.locator('[data-testid="step-nav-research"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ai-research-interface"]')).toBeVisible();
+    await expect(page.locator('[data-testid="start-ai-research-button"]')).toBeVisible();
+    
+    // Start AI research (topic already filled during creation)
+    await startAIResearch(page);
+    
+    // Wait for research to complete
+    await waitForResearchCompletion(page);
+    
+    // Verify research content is generated
+    await expect(page.locator('[data-testid="ai-research-content-label"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ai-research-content"]')).toBeVisible();
+    
+    // Test wizard suggestions functionality
+    await test.step('Submit wizard request for research modification', async () => {
+      // Click on the wizard input field
+      const wizardInput = page.locator('[data-testid="wizard-input"]');
+      await expect(wizardInput).toBeVisible();
+      await expect(wizardInput).toBeEnabled();
+      await wizardInput.click();
+      
+      // Type a request to modify the research
+      const modificationRequest = 'Please add more information about AI ethics and privacy concerns in healthcare applications';
+      await wizardInput.fill(modificationRequest);
+      
+      // Submit the request
+      await wizardInput.press('Enter');
+      
+      // Verify the request appears in the wizard chat
+      await expect(page.locator(`text=${modificationRequest}`)).toBeVisible();
+    });
+    
+    await test.step('Wait for wizard to process and generate suggestion', async () => {
+      // Wait for processing message
+      await expect(page.locator('text=Processing your request')).toBeVisible();
+      
+      // Wait for suggestion to be generated (using data-testid instead of specific text)
+      // Be more flexible - wait for any wizard response
+      await page.waitForTimeout(10000); // Give time for processing
+      
+      // Check if a suggestion was generated OR if there's a response message
+      const hasSuggestion = await page.locator('[data-testid="wizard-suggestion"]').isVisible();
+      const hasResponse = await page.locator('[data-testid="wizard-message-assistant"]').count() > 1;
+      
+      console.log(`Has suggestion: ${hasSuggestion}, Has response: ${hasResponse}`);
+      
+      // At least one should be true
+      expect(hasSuggestion || hasResponse).toBe(true);
+      
+      if (hasSuggestion) {
+        console.log('✅ Wizard suggestion generated successfully');
+        
+        // Verify suggestion components are present
+        await expect(page.locator('[data-testid="wizard-apply-button"]')).toBeVisible();
+        await expect(page.locator('[data-testid="wizard-dismiss-button"]')).toBeVisible();
+        
+        // Apply the changes
+        const applyButton = page.locator('[data-testid="wizard-apply-button"]');
+        await applyButton.click();
+        
+        // Wait for the suggestion to disappear (indicating changes were applied)
+        await expect(page.locator('[data-testid="wizard-suggestion"]')).not.toBeVisible({ timeout: 15000 });
+        
+        console.log('✅ Wizard suggestion applied successfully');
+      } else {
+        console.log('ℹ️ Wizard provided a response but no suggestion was generated');
+      }
+    });
+    
+    await test.step('Verify research content is accessible', async () => {
+      // Check that the research content is still visible and accessible
+      const researchContent = page.locator('[data-testid="ai-research-content"]').first();
+      await expect(researchContent).toBeVisible();
+      
+      // Verify the research step is still visible and functional
+      const stepButton = page.locator('[data-testid="step-nav-research"]');
+      await expect(stepButton).toBeVisible();
+      
+      console.log('✅ Research content remains accessible after wizard interaction');
+    });
+  });
+  
+  test('should handle wizard gracefully when no suggestions are needed', async ({ page }) => {
+    // Create a new presentation
+    const presentationId = await createPresentation(page, 'Research Wizard Simple Test', 'Simple Test Topic');
+    
+    // Generate research content first
+    await startAIResearch(page);
+    await waitForResearchCompletion(page);
+    
+    // Test with a simple informational request
+    const wizardInput = page.locator('[data-testid="wizard-input"]');
+    await wizardInput.click();
+    await wizardInput.fill('What is this research about?');
+    await wizardInput.press('Enter');
+    
+    // Wait for response
+    await page.waitForTimeout(5000);
+    
+    // Should not crash and wizard should remain functional
+    await expect(wizardInput).toBeVisible();
+  });
+  
+  test('should maintain wizard functionality on research page', async ({ page }) => {
+    // Create presentation and generate research
+    const presentationId = await createPresentation(page, 'Wizard Functionality Test', 'Test Research Topic');
+    
+    await startAIResearch(page);
+    await waitForResearchCompletion(page);
+    
+    // Test basic wizard functionality
+    const wizardInput = page.locator('[data-testid="wizard-input"]');
+    await expect(wizardInput).toBeVisible();
+    
+    // Test that we can type in the wizard
+    await wizardInput.click();
+    await wizardInput.fill('Test message');
+    
+    // Verify the text was entered
+    const inputValue = await wizardInput.inputValue();
+    expect(inputValue).toBe('Test message');
+    
+    console.log('✅ Wizard input functionality verified');
+  });
+}); 


### PR DESCRIPTION
## Summary
- allow wizard to request research updates
- implement `modify_research` tool and backend endpoints
- expose modify/save research API calls to frontend
- update wizard suggestion component for research results
- apply research updates when user accepts

## Testing
- `make test-backend-offline`
- `make test-frontend` *(fails: connect ECONNREFUSED to localhost:8000)*